### PR TITLE
Use ui-router to link to other pages/states

### DIFF
--- a/src/templates/build.html
+++ b/src/templates/build.html
@@ -56,7 +56,7 @@ controller: BuildController
             ng-controller="BuildController"
             ng-class="{ 'active': $state.current.name === 'project'}"
             ng-hide="$state.current.name === 'home'">
-            <a href="../kashti/#!/project/{{ build.project_id }}">Project Overview</a></li>
+            <a ui-sref="project({ id: build.project_id })">Project Overview</a></li>
           <li ng-show="$state.current.name === 'build'"><a>Build <em>{{ build.id}}</em></a></li>
         </ul>
       </div>
@@ -75,7 +75,7 @@ controller: BuildController
 
               <div class="build-header">
                 <h1>
-                  <a href="../kashti/#!/project/{{ build.project_id }}" title="Back to Build list"><i class="ion-chevron-left icon"></i></a>
+                  <a ui-sref="project({ id: build.project_id })" title="Back to Build list"><i class="ion-chevron-left icon"></i></a>
                   Build &nbsp;<em>{{ build.id }}</em>
                 </h1>
 

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -44,7 +44,7 @@ controllerAs: ProjectBuildsController
                     'project-failed': projectsbuild.lastBuild.worker.status == 'Failed',
                     'project-active': projectsbuild.lastBuild.worker.status == 'Active'
                   }">
-                    <a ui-sref="project({ id: projectsbuild.project.id   })">
+                    <a ui-sref="project({ id: projectsbuild.project.id })">
                       <div class="status">
                         <div class="success" ng-show="projectsbuild.lastBuild.worker.status == 'Succeeded'"><i class="icon ion-checkmark-circled status-success"></i></div>
                         <div class="failed" ng-show="projectsbuild.lastBuild.worker.status == 'Failed'"><i class="icon ion-close-circled status-fail"></i></div>

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -7,22 +7,6 @@ controllerAs: ProjectBuildsController
 
 <div class="medium-grid-block collapse medium-12 large-12 vertical">
   <div class="grid-block collapse vertical">
-
-    <!-- topbar #header -->
-    <div id="header" class="shrink collapse grid-content">
-      <div class="menu-group primary">
-        <div class="menu-group-left">
-          <ul class="menu-bar">
-            <li
-              ng-controller="ProjectController as project"
-              ng-hide="$state.current.name === 'home'">
-              <a href="../kashti/#!/project/{{project.id}}">{{project.name}}</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <!-- /#header -->
-
     <div class="grid-block vertical">
       <div class="grid-content content-wrap">
 
@@ -60,8 +44,7 @@ controllerAs: ProjectBuildsController
                     'project-failed': projectsbuild.lastBuild.worker.status == 'Failed',
                     'project-active': projectsbuild.lastBuild.worker.status == 'Active'
                   }">
-                    <a href="../kashti/#!/project/{{projectsbuild.project.id}}" class="">
-
+                    <a ui-sref="project({ id: projectsbuild.project.id   })">
                       <div class="status">
                         <div class="success" ng-show="projectsbuild.lastBuild.worker.status == 'Succeeded'"><i class="icon ion-checkmark-circled status-success"></i></div>
                         <div class="failed" ng-show="projectsbuild.lastBuild.worker.status == 'Failed'"><i class="icon ion-close-circled status-fail"></i></div>

--- a/src/templates/home.html
+++ b/src/templates/home.html
@@ -17,12 +17,6 @@ controllerAs: ProjectBuildsController
               ng-controller="ProjectController as project"
               ng-hide="$state.current.name === 'home'">
               <a href="../kashti/#!/project/{{project.id}}">{{project.name}}</a></li>
-            <li
-              ng-controller="BuildController"
-              ng-class="{ 'active': $state.current.name === 'project'}"
-              ng-hide="$state.current.name === 'home'">
-              <a href="../kashti/#!/project">Master</a></li>
-            <li ng-show="$state.current.name === 'build'"><a href="/#!/build/{{build.id}}">Build {{ $stateParams.build.id}}</a></li>
           </ul>
         </div>
       </div>

--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -65,7 +65,7 @@ controller: ProjectController
 
         <ul class="grid-content build-list" ng-controller="BuildsController">
           <li ng-repeat="build in builds | orderBy: reverse:true" class="medium-grid-block build-item">
-            <a href="../kashti/#!/build/{{build.id}}" class="grid-block">
+            <a ui-sref="build({ id: build.id })" class="grid-block">
 
               <span class="act-state collapse {{ build.worker.status }}" ng-class="{
                 'success': build.worker.status == 'Succeeded',

--- a/src/templates/project.html
+++ b/src/templates/project.html
@@ -43,23 +43,6 @@ controller: ProjectController
 <div class="medium-grid-block collapse medium-10 large-10 vertical">
   <div class="grid-block collapse vertical">
 
-    <!-- topbar #header -->
-    <div id="header" class="shrink collapse grid-content vertical">
-      <div class="menu-group primary">
-        <div class="menu-group-left">
-          <ul class="menu-bar">
-            <li
-              ng-controller="BuildController"
-              ng-class="{ 'active': $state.current.name === 'project'}"
-              ng-hide="$state.current.name === 'home'">
-              <a href="../kashti/#!/project/{{project.id}}">Project Overview</a></li>
-            <li ng-show="$state.current.name === 'build'"><a href="/#!/build/{{build.id}}">Build {{ $stateParams.build.id}}</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <!-- /#header -->
-
     <div class="grid-block vertical">
       <div class="grid-content content-wrap">
 


### PR DESCRIPTION
Small change to use ui-router to manage links (and states). Instead of using `<a href="/my/sub/page">` in a page to access another page, it's common practice to use the router. Clicking the link will trigger a state transition with optional parameters. Also middle-clicking, right-clicking, and ctrl-clicking on the link will be handled natively by the browser.

Also removed (what I think is at the moment) dead menu bar code. We can always put it back in once it's live.

Related to #5 