### PR TITLE
fix(chart): remove semicolon typo in chart

### DIFF
--- a/charts/kashti/templates/js-configmap.yaml
+++ b/charts/kashti/templates/js-configmap.yaml
@@ -8,5 +8,5 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   "settings.js": |-
-    var brigadeApiURL = '{{ default "http://localhost:7744" .Values.brigade.apiServer }};'
+    var brigadeApiURL = '{{ default "http://localhost:7744" .Values.brigade.apiServer }}';
     // End

--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -25,9 +25,9 @@ ingress:
     #   hosts:
     #     - chart-example.local
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious 
-  # choice for the user. This also increases chances charts run on environments with little 
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following 
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
Typo I introduced in the kashti chart causes the settings file (which contains the brigade API server configured by helm) to look like this (note the misplaced semicolon):

```js
var brigadeApiURL = 'http://52.234.132.82:7745;'
// End
```

Because it's valid javascript, no console errors are reported. presumably the angular http provider reads this value, sees that it's invalid, and errors silently, which made this a tricky to find.