### PR TITLE
Update chart and documentation for brig proxy

### DIFF
--- a/charts/kashti/templates/NOTES.txt
+++ b/charts/kashti/templates/NOTES.txt
@@ -11,7 +11,5 @@
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
   echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl port-forward $POD_NAME 8080:{{ .Values.service.externalPort }}
+  To connect to the Kashti dashboard, use execute brig proxy and access it on http://localhost:8081 (you can provide the --port <local-port> flag to specify another local port)
 {{- end }}

--- a/charts/kashti/values.yaml
+++ b/charts/kashti/values.yaml
@@ -8,7 +8,7 @@ image:
   pullPolicy: IfNotPresent
 service:
   name: kashti
-  type: LoadBalancer
+  type: ClusterIP
   externalPort: 80
   internalPort: 80
 ingress:

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -38,16 +38,10 @@ image:
 ```console
 $ eval $(minikube docker-env)
 $ yarn docker-build
-$ helm install -n brigade-ui chart/kashti --set brigade.apiServer=http://localhost:7745
+$ helm install -n kashti ./charts/kashti
 ```
 
 This will push a copy of the Docker image into your Minikube docker registry and
 then install the chart.
 
-The value of `brigade.apiServer` should be the fully qualified URL to your Brigade
-installation's API server. This is the URL that the _client_ will see, so you
-may need to use the outside IP address, not the cluster IP.
-
-The example above can be used along with a few `kubectl port-forward` commands to
-locally access your Kashti UI. See the [Install Guide](install.md) for more.
-
+Then, use `brig proxy` to start a tunnel to the Kashti pod inside your cluster.

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ To install the Brigade UI to a Kubernetes cluster:
 1. [Install Brigade](https://github.com/Azure/brigade)
 2. Clone this repo and `cd` into the root of the repo
 3. `helm install -n kashti ./charts/kashti`
-3. `brig proxy` - then access through your browser at http://localhost:8081
+4. `brig proxy` - then access through your browser at http://localhost:8081
 
 > Note that by default, this will create two local tunnels, one on port 7745 (the default port Kashti expects for the Brigae API) and one on port 8081, where you can access the dashboard.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,76 +4,28 @@ This document covers the installation of Kashti into a Kubernetes cluster. Kasht
 developers will find developer-specific documentation in the [Developer Guide](developers.md).
 
 Kashti is a client-side JavaScript application. It makes requests to the Brigade API
-server (which is installed as part of Brigade). **The browser that Kashti is run from
-_must_ have access to the Brigade API server.**
+server (which is installed as part of Brigade). We will use the `brig` command line to create HTTP tunnels to the Brigade API server and to the Kashti dashboard.
+
+> If you don't have the `brig` command line already, [check out the Brigade documentation on how to build it](https://github.com/Azure/brigade/blob/master/docs/topics/developers.md#building-source) 
 
 ## Kubernetes Installation
 
 To install the Brigade UI to a Kubernetes cluster:
 
 1. [Install Brigade](https://github.com/Azure/brigade)
-2. Get the IP address or hostname of the Brigade API service. You can often do this with `helm status brigade-server`
-3. Clone this repo and `cd` into the root of the repo
-3. Install the chart: `helm install charts/kashti --name kashti --set brigade.apiServer=http://IP:7745`, where IP is the
-  IP or hostname of the Brigade API service. See Option 1 and Option 2 below to
-  determine which value to put here.
+2. Clone this repo and `cd` into the root of the repo
+3. `helm install -n kashti ./charts/kashti`
+3. `brig proxy` - then access through your browser at http://localhost:8081
 
-_The address or hostname in `brigade.apiServer` is the location that the browser
-will contact to get information about your projects, builds, and jobs._
+> Note that by default, this will create two local tunnels, one on port 7745 (the default port Kashti expects for the Brigae API) and one on port 8081, where you can access the dashboard.
 
-To access Kashti from a browser outside of a cluster, you have two options at the
-moment:
-
-1. Open a tunnel from the browser to the destination cluster.
-2. Allow outside access to your API and Kashti deployments.
-
-> OAuth2 authentication is on the roadmap, but not yet complete. At this point,
-> opening the service to the outside world will allow unauthenticated access
-> to your project's dashboard.
-
-Both examples below assume you are in the root of the checked-out Kashti git
-repository.
-
-## Option 1: Tunnel from Local Browser to Cluster Services
-
-In this example, we will allow the browser to proxy HTTP requests into the cluster
-without opening up the cluster hosts to public traffic.
-
-First, you must setup Brigade. The normal Brigade installation will work fine here:
-
-```console
-$ helm repo add brigade https://azure.github.io/brigade
-$ helm install brigade/brigade --name brigade-server
-```
-
-Once Brigade is running, you can install Kashti, setting the API server endpoint
-to your localhost.
-
-```console
-$ helm install -n kashti ./charts/kashti --set brigade.apiServer=http://localhost:7745
-```
-
-This will install Kashti, and configure it _specifically for tunneling_. Now you
-will need to start two port-forwarding tunnels in the background: One to Kashti
-and the other to the Brigade API server:
-
-```console
-$ kubectl get po | grep brigade-server-brigade-api | awk '{ print $1 }'
-brigade-server-brigade-api-559fb8df99-kz5wl
-$ kubectl port-forward brigade-server-brigade-api-559fb8df99-kz5wl 7745 &
-$ kubectl get po | grep kashti | awk '{ print $1 }'
-kashti-kashti-54bf55b988-dsbhf
-$ kubectl port-forward kashti-kashti-54bf55b988-dsbhf 8080:80 &
-```
-
-At this point, you have:
-
-- Kashti listening on http://localhost:8080/kashti/. This is the URL you put in your browser.
-- Brigade API listening on http://localhost:7745, with Kashti automatically configed
-  to talk to it.
+> You can specify another port to access the dashboard by usig `brig proxy --port <another-port>`
 
 
-## Option 2: Allow Outside Access to Your Services
+> If you specify another port for the API server when installing the chart - `helm install -n kashti ./charts/kashti --set brigade.apiServer=http://localhost:<other-port>`, when connecting using `brig proxy` you must also pass the new port as parameter: `brig proxy --api-port <other-port>`
+
+
+## Allow Outside Access to Your Services
 
 You may choose to open up a pair of services to the outside network and allow
 inbound traffic. The two services you will need to expose are:


### PR DESCRIPTION
- update the default chart service type to `ClusterIP`
- update the NOTES.txt message if the service type is `ClusterIP` to use `brig proxy`
- update the install and developer documentation