### PR TITLE
Ensure project and build data is preloaded before navigating to project page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,10 +6,14 @@ import { BuildComponent } from './build/build.component';
 import { StyleGuideComponent } from './style-guide/style-guide.component';
 import { ProjectResolver } from './services/project.resolver';
 import { BuildsResolver } from './services/builds.resolver';
+import { ProjectsBuildResolver } from './services/projects-build.resolver';
 
 const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
-  { path: 'dashboard', component: DashboardComponent },
+  { path: 'dashboard',
+    component: DashboardComponent,
+    resolve: { projectsBuilds: ProjectsBuildResolver }
+  },
   { path: 'project/:id',
     component: ProjectComponent,
     resolve: { project: ProjectResolver, builds: BuildsResolver }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,13 +5,14 @@ import { ProjectComponent } from './project/project.component';
 import { BuildComponent } from './build/build.component';
 import { StyleGuideComponent } from './style-guide/style-guide.component';
 import { ProjectResolver } from './services/project.resolver';
+import { BuildsResolver } from './services/builds.resolver';
 
 const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
   { path: 'dashboard', component: DashboardComponent },
   { path: 'project/:id',
     component: ProjectComponent,
-    resolve: { project: ProjectResolver}
+    resolve: { project: ProjectResolver, builds: BuildsResolver }
   },
   { path: 'build/:id', component: BuildComponent },
   { path: 'styleguide', component: StyleGuideComponent }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,11 +4,15 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { ProjectComponent } from './project/project.component';
 import { BuildComponent } from './build/build.component';
 import { StyleGuideComponent } from './style-guide/style-guide.component';
+import { ProjectResolver } from './services/project.resolver';
 
 const routes: Routes = [
   { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
   { path: 'dashboard', component: DashboardComponent },
-  { path: 'project/:id', component: ProjectComponent },
+  { path: 'project/:id',
+    component: ProjectComponent,
+    resolve: { project: ProjectResolver}
+  },
   { path: 'build/:id', component: BuildComponent },
   { path: 'styleguide', component: StyleGuideComponent }
 ];

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { ApiProjectService } from './services/project/api-project.service';
 import { BuildService } from './services/build/build.service';
 import { ProjectResolver } from './services/project.resolver';
 import { BuildsResolver } from './services/builds.resolver';
+import { ProjectsBuildResolver } from './services/projects-build.resolver';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { BuildsResolver } from './services/builds.resolver';
     { provide: BuildService, useClass: environment.buildServiceType },
     { provide: ProjectService, useClass: environment.projectServiceType },
     ProjectResolver,
+    ProjectsBuildResolver,
     BuildsResolver
 
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { BuildStatusBadgeComponent } from './build-status-badge/build-status-bad
 import { ApiProjectService } from './services/project/api-project.service';
 import { BuildService } from './services/build/build.service';
 import { ProjectResolver } from './services/project.resolver';
+import { BuildsResolver } from './services/builds.resolver';
 
 @NgModule({
   declarations: [
@@ -41,7 +42,8 @@ import { ProjectResolver } from './services/project.resolver';
   providers: [
     { provide: BuildService, useClass: environment.buildServiceType },
     { provide: ProjectService, useClass: environment.projectServiceType },
-    ProjectResolver
+    ProjectResolver,
+    BuildsResolver
 
   ],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { ProjectComponent } from './project/project.component';
 import { BuildStatusBadgeComponent } from './build-status-badge/build-status-badge.component';
 import { ApiProjectService } from './services/project/api-project.service';
 import { BuildService } from './services/build/build.service';
+import { ProjectResolver } from './services/project.resolver';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import { BuildService } from './services/build/build.service';
   providers: [
     { provide: BuildService, useClass: environment.buildServiceType },
     { provide: ProjectService, useClass: environment.projectServiceType },
+    ProjectResolver
 
   ],
   bootstrap: [AppComponent]

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <div class="row small-up-1 medium-up-1 large-up-2 xlarge-up-3 dash-wrapper">
-  <section class="column" *ngFor="let projectBuild of projectBuilds">
+  <section class="column" *ngFor="let projectBuild of projectsBuilds">
     <div class="project">
       <a routerLink="/project/{{projectBuild.project.id}}">
         <div class="status">

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -31,7 +31,7 @@ describe('DashboardComponent', () => {
     fixture.detectChanges();
   });
 
-  xit('should create', () => {
+  it('should create', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, Inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
 import { MomentModule } from 'angular2-moment';
 
-import { ProjectBuild } from '../models/ProjectBuild';
 import { ProjectService } from '../services/project/project.service';
 
 @Component({
@@ -12,21 +13,12 @@ import { ProjectService } from '../services/project/project.service';
 
 export class DashboardComponent implements OnInit {
 
-  projectBuilds: ProjectBuild[];
+  projectsBuilds;
 
-  constructor(private projectService: ProjectService) { }
+  constructor(private route: ActivatedRoute) { }
 
   ngOnInit() {
-    this.getProjectBuilds();
-  }
-
-  getProjectBuilds(): void {
-    this.projectService.getProjectBuilds()
-      .subscribe(returnedData => {
-        this.projectBuilds = returnedData;
-      },
-      error => console.error(error)
-    );
+    this.projectsBuilds = this.route.snapshot.data['projectsBuilds'];
   }
 
   showStatus(projectBuild) {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -13,7 +13,7 @@ import { ProjectService } from '../services/project/project.service';
 
 export class DashboardComponent implements OnInit {
 
-  projectsBuilds;
+  projectsBuilds = [];
 
   constructor(private route: ActivatedRoute) { }
 

--- a/src/app/mock/projects-builds.ts
+++ b/src/app/mock/projects-builds.ts
@@ -1,6 +1,6 @@
-import { ProjectBuild } from '../models/ProjectBuild';
+import { ProjectsBuild } from '../models/ProjectsBuild';
 
-export const ProjectsBuilds: ProjectBuild[] = [
+export const ProjectsBuilds: ProjectsBuild[] = [
   {
     'project': {
       'id': 'brigade-29d38c7477ecee18e184b69bec354fc350605c51bc16d4dd2b6073',

--- a/src/app/models/ProjectsBuild.ts
+++ b/src/app/models/ProjectsBuild.ts
@@ -3,7 +3,7 @@ import { Repo } from './Repo';
 import { Kubernetes } from './Kubernetes';
 import { LastBuild } from './LastBuild';
 
-export interface ProjectBuild {
+export interface ProjectsBuild {
   project: Project;
   lastBuild?: LastBuild;
 }

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -48,7 +48,7 @@
 
             <span class="act-author ng-binding">
               <span class="act-avatar">
-                <i [ngClass]="calculateProviderLogoClass(build.provider)"></i>
+                <i [ngClass]="CalculateProviderLogoClass(build.provider)"></i>
               </span>
               {{ build.provider }}
             </span>

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 import { MomentModule } from 'angular2-moment/moment.module';
 
 import { ProjectComponent } from './project.component';
@@ -7,6 +8,33 @@ import { ProjectComponent } from './project.component';
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
   let fixture: ComponentFixture<ProjectComponent>;
+  let project;
+
+  project = {
+    id: 'brigade-29d38c7477ecee18e184b69bec354fc350605c51bc16d4dd2b6073',
+    name: 'kashti/localdev',
+    repo: {
+      name: 'github.com/kashti/localdev',
+      cloneURL: 'https://github.com/kashti/localdev.git'
+    },
+    defaultScript: '',
+    kubernetes: {
+      namespace: 'default',
+      vcsSidecar: '',
+      buildStorageSize: '50Mi'
+    },
+    github: {
+      baseURL: '',
+      uploadURL: ''
+    },
+    secrets: {},
+    worker: {
+      registry: '',
+      name: '',
+      tag: '',
+      pullPolicy: ''
+    }
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -16,7 +44,11 @@ describe('ProjectComponent', () => {
           [{ path: '', component: ProjectComponent }]
         ),
         MomentModule
-      ]
+      ],
+      providers: [{
+        provide: ActivatedRoute,
+        useValue: {snapshot: {data: {'project': project}}}
+      }]
     })
     .compileComponents();
   }));
@@ -27,7 +59,12 @@ describe('ProjectComponent', () => {
     fixture.detectChanges();
   });
 
-  xit('should create', () => {
+  it('should create when project data is available', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should create when no project data is available', () => {
+    project = {};
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -24,24 +24,15 @@ export class ProjectComponent implements OnInit {
     private projectService: ProjectService,
     private buildService: BuildService,
     private route: ActivatedRoute,
-
   ) { }
 
   ngOnInit() {
     const projectId = this.route.snapshot.paramMap.get('id');
-    this.getProject(projectId);
+    this.project = this.route.snapshot.data['project'];
     this.getBuilds(projectId);
   }
 
-  getProject(projectId): void {
-    this.projectService.getProject(projectId)
-      .subscribe(returnedProject => {
-        this.project = returnedProject;
-      },
-      error => console.error(error));
-  }
-
-  getBuilds(projectId): void {
+  getBuilds(projectId) {
     this.buildService.getBuilds(projectId)
       .subscribe(returnedBuilds => {
         this.builds = returnedBuilds;

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -27,17 +27,8 @@ export class ProjectComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    const projectId = this.route.snapshot.paramMap.get('id');
     this.project = this.route.snapshot.data['project'];
-    this.getBuilds(projectId);
-  }
-
-  getBuilds(projectId) {
-    this.buildService.getBuilds(projectId)
-      .subscribe(returnedBuilds => {
-        this.builds = returnedBuilds;
-      },
-      error => console.error(error));
+    this.builds = this.route.snapshot.data['builds'];
   }
 
   calculateProviderLogoClass(buildProvider) {

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -1,14 +1,9 @@
 import { Component, OnInit, HostBinding } from '@angular/core';
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/switchMap';
 
 import { MomentModule } from 'angular2-moment';
-
-import { Build } from '../models/Build';
-import { Project } from '../models/Project';
-import { ProjectService } from '../services/project/project.service';
-import { BuildService } from '../services/build/build.service';
 
 @Component({
   selector: 'app-project',
@@ -21,8 +16,6 @@ export class ProjectComponent implements OnInit {
   builds;
 
   constructor(
-    private projectService: ProjectService,
-    private buildService: BuildService,
     private route: ActivatedRoute,
   ) { }
 

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -31,7 +31,7 @@ export class ProjectComponent implements OnInit {
     this.builds = this.route.snapshot.data['builds'];
   }
 
-  calculateProviderLogoClass(buildProvider) {
+  CalculateProviderLogoClass(buildProvider) {
     switch (buildProvider) {
       case 'github':
         return 'icon ion-logo-github';

--- a/src/app/services/builds.resolver.spec.ts
+++ b/src/app/services/builds.resolver.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { BuildsResolver } from './builds.resolver';
+import { BuildService } from './build/build.service';
+
+
+describe('BuildsResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        BuildsResolver,
+        BuildService
+      ]
+    });
+  });
+
+  it('should be created', inject([BuildsResolver], (service: BuildsResolver) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/builds.resolver.ts
+++ b/src/app/services/builds.resolver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+import { BuildService } from './build/build.service';
+import { Build } from '../models/Build';
+
+@Injectable()
+export class BuildsResolver implements Resolve<Build[]> {
+
+  constructor(private buildService: BuildService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.buildService.getBuilds(route.paramMap.get('id'));
+  }
+}

--- a/src/app/services/project.resolver.spec.ts
+++ b/src/app/services/project.resolver.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ProjectResolver } from './project.resolver';
+import { ProjectService } from './project/project.service';
+
+
+describe('ProjectResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProjectResolver,
+        ProjectService
+      ]
+    });
+  });
+
+  it('should be created', inject([ProjectResolver], (service: ProjectResolver) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/project.resolver.ts
+++ b/src/app/services/project.resolver.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/catch';
 
 import { ProjectService } from './project/project.service';
 import { Project } from '../models/Project';
@@ -9,7 +11,8 @@ export class ProjectResolver implements Resolve<Project> {
 
   constructor(private projectService: ProjectService) {}
 
-  resolve(route: ActivatedRouteSnapshot) {
-    return this.projectService.getProject(route.paramMap.get('id'));
+  resolve(route: ActivatedRouteSnapshot): Observable<Project> {
+    return this.projectService.getProject(route.paramMap.get('id'))
+      .catch((e: any) => Observable.throw(console.log(e)));
   }
 }

--- a/src/app/services/project.resolver.ts
+++ b/src/app/services/project.resolver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+import { ProjectService } from './project/project.service';
+import { Project } from '../models/Project';
+
+@Injectable()
+export class ProjectResolver implements Resolve<Project> {
+
+  constructor(private projectService: ProjectService) {}
+
+  resolve(route: ActivatedRouteSnapshot) {
+    return this.projectService.getProject(route.paramMap.get('id'));
+  }
+}

--- a/src/app/services/project/api-project.service.ts
+++ b/src/app/services/project/api-project.service.ts
@@ -5,7 +5,7 @@ import { of } from 'rxjs/observable/of';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { environment } from '../../../environments/environment.prod';
-import { ProjectBuild } from '../../models/ProjectBuild';
+import { ProjectsBuild } from '../../models/ProjectsBuild';
 import { Project } from '../../models/Project';
 import { ProjectService } from './project.service';
 import { BRIGADE_API_HOST } from '../../app.config';
@@ -21,11 +21,11 @@ export class ApiProjectService implements ProjectService {
 
   constructor(private http: HttpClient) {}
 
-  getProjectBuilds(): Observable<ProjectBuild[]> {
+  getProjectBuilds(): Observable<ProjectsBuild[]> {
     const projectBuildsUrl = `${BRIGADE_API_HOST}/v1/projects-build`;
 
     return this.http
-      .get<ProjectBuild[]>(projectBuildsUrl, httpOptions);
+      .get<ProjectsBuild[]>(projectBuildsUrl, httpOptions);
   }
 
   getProject(projectId): Observable<Project> {

--- a/src/app/services/project/mock-project.service.ts
+++ b/src/app/services/project/mock-project.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/delay';
 
-import { ProjectBuild } from '../../models/ProjectBuild';
+import { ProjectsBuild } from '../../models/ProjectsBuild';
 import { Project } from '../../models/Project';
 
 import { ProjectsBuilds } from '../../mock/projects-builds';
@@ -13,7 +13,7 @@ import { filter } from 'rxjs/operators';
 
 @Injectable()
 export class MockProjectService implements ProjectService {
-    getProjectBuilds(): Observable<ProjectBuild[]> {
+    getProjectBuilds(): Observable<ProjectsBuild[]> {
         return Observable.of(ProjectsBuilds).delay(500);
     }
 

--- a/src/app/services/project/mock-project.service.ts
+++ b/src/app/services/project/mock-project.service.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@angular/core';
 import { ProjectService } from './project.service';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
+import 'rxjs/add/operator/delay';
+
 import { ProjectBuild } from '../../models/ProjectBuild';
 import { Project } from '../../models/Project';
 
@@ -12,11 +14,11 @@ import { filter } from 'rxjs/operators';
 @Injectable()
 export class MockProjectService implements ProjectService {
     getProjectBuilds(): Observable<ProjectBuild[]> {
-        return Observable.of(ProjectsBuilds);
+        return Observable.of(ProjectsBuilds).delay(500);
     }
 
     getProject(projectId: string): Observable<Project> {
       const filteredList = Projects.filter((project: Project) => project.id === projectId);
-      return Observable.of(filteredList[0]);
+      return Observable.of(filteredList[0]).delay(500);
     }
 }

--- a/src/app/services/project/project.service.ts
+++ b/src/app/services/project/project.service.ts
@@ -1,8 +1,8 @@
 import { Observable } from 'rxjs/Observable';
-import { ProjectBuild } from '../../models/ProjectBuild';
+import { ProjectsBuild } from '../../models/ProjectsBuild';
 import { Project } from '../../models/Project';
 
 export abstract class ProjectService {
-    abstract getProjectBuilds(): Observable<ProjectBuild[]>;
+    abstract getProjectBuilds(): Observable<ProjectsBuild[]>;
     abstract getProject(projectId: string): Observable<Project>;
 }

--- a/src/app/services/projects-build.resolver.spec.ts
+++ b/src/app/services/projects-build.resolver.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ProjectResolver } from './project.resolver';
+import { ProjectService } from './project/project.service';
+
+
+describe('ProjectResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProjectResolver,
+        ProjectService
+      ]
+    });
+  });
+
+  it('should be created', inject([ProjectResolver], (service: ProjectResolver) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/projects-build.resolver.ts
+++ b/src/app/services/projects-build.resolver.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+import { ProjectService } from './project/project.service';
+import { ProjectsBuild } from '../models/ProjectsBuild';
+
+@Injectable()
+export class ProjectsBuildResolver implements Resolve<ProjectsBuild[]> {
+
+  constructor(private projectService: ProjectService) {}
+
+  resolve() {
+    return this.projectService.getProjectBuilds();
+  }
+}

--- a/src/app/services/projectsbuild.resolver.spec.ts
+++ b/src/app/services/projectsbuild.resolver.spec.ts
@@ -1,0 +1,20 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ProjectsBuildResolver } from './projects-build.resolver';
+import { ProjectService } from './project/project.service';
+
+
+describe('ProjectsBuildResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProjectsBuildResolver,
+        ProjectService
+      ]
+    });
+  });
+
+  it('should be created', inject([ProjectsBuildResolver], (service: ProjectsBuildResolver) => {
+    expect(service).toBeTruthy();
+  }));
+});


### PR DESCRIPTION
Fixes #157, and also preloads data on the dashboard, too.

Route resolvers are pretty neat! This fixes loading jank on all component pages.

To test, load kashti in prod and dev mode:
- dev: `ng serve` and click around
- prod: `ng serve --env=prod` and click around
