### PR TITLE
[#155] set a base width for @Component selector elements

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,5 +1,5 @@
 <div class="row small-up-1 medium-up-1 large-up-2 xlarge-up-3 dash-wrapper">
-  <section class="column" *ngFor="let projectBuild of projectsBuilds">
+  <section class="columns" *ngFor="let projectBuild of projectsBuilds">
     <div class="project">
       <a routerLink="/project/{{projectBuild.project.id}}">
         <div class="status">

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -4,6 +4,7 @@
 
 :host {
   padding: 0.925rem 4.25% 5rem;
+  min-width: 91.5%;
 }
 
 @mixin icon {

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,9 +1,9 @@
 @import 'global_variables';
 @import 'global_states';
 
-.dash-wrapper {
-  padding: 0.925rem 4.5% 5rem;
 
+:host {
+  padding: 0.925rem 4.25% 5rem;
 }
 
 @mixin icon {

--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -1,6 +1,11 @@
 @import 'global_variables';
 @import 'global_states';
 
+
+:host {
+  min-width: 91.5%;
+}
+
 .breadcrumb-bar {
   background: #fff;
   position: fixed;


### PR DESCRIPTION
Resolves a min-width issue with the dashboard rendering. Screenshot:

<img width="1511" alt="screen shot 2018-03-21 at 2 29 29 pm" src="https://user-images.githubusercontent.com/686194/37715684-8ee74578-2d14-11e8-8120-549689817ecf.png">

---

When the page contents are reduced, the page contracts/shrinks - the base element of each page `app-dashboard`, `app-root` etc was ignoring grid rules. This enforces a min-width for component template selectors.

Closes #155.