### PR TITLE
proposed: Display correct build project status 

### DIFF
--- a/src/_global_variables.scss
+++ b/src/_global_variables.scss
@@ -26,6 +26,7 @@ $light4: #fff;
 $success: #70ae29;
 $fail: #d10015;
 $error: $fail;
+$pending: #cfaa59;
 $warn: darken(#f5a623, 2.5%);
 $active: $brand2;
 

--- a/src/app/build-status-badge/build-status-badge.component.html
+++ b/src/app/build-status-badge/build-status-badge.component.html
@@ -1,21 +1,11 @@
-<span class="act-state collapse active">
-  <div class="spinner" title="In progress"></div>
+<span *ngIf="running(status); else elseBlock" class="act-state collapse running">
+  <div class="spinner" title="Running"></div>
 </span>
 
-<span class="act-state collapse success">
-  <div class="success" title="Succeeded">
-    <i class="icon ion-md-checkmark-circle"></i>
-  </div>
-</span>
-
-<span class="act-state collapse failed">
-  <div class="failed" title="Failed">
-    <i class="icon ion-md-close-circle"></i>
-  </div>
-</span>
-
-<span class="act-state collapse unknown">
-  <span class="unknown">
-    <i class="icon ion-md-radio-button-off"></i>
+<ng-template #elseBlock>
+  <span class="act-state collapse {{status | lowercase}}">
+    <span class="{{status | lowercase}}" title="{{status}}">
+      <i [ngClass]="calculateIconClass(status)"></i>
+    </span>
   </span>
-</span>
+</ng-template>

--- a/src/app/build-status-badge/build-status-badge.component.scss
+++ b/src/app/build-status-badge/build-status-badge.component.scss
@@ -1,0 +1,108 @@
+@import 'global_variables';
+@import 'global_states';
+
+span {
+  font-family: $mono;
+  font-size: 0.825rem;
+  line-height: 2.25;
+  letter-spacing: -0.05em;
+  color: darken($dark3, 10%);
+  display: inline-block;
+  @include transition;
+}
+
+.act-state {
+  padding-top: 0.1rem;
+  padding-left: 0.1rem;
+  position: relative;
+  line-height: 1.725;
+  min-width: 3.5%;
+  z-index: 900;
+
+  div {
+    display: none;
+  }
+
+  &.succeeded {
+    span.succeeded {
+      display: inline-block;
+      color: $success;
+    }
+  }
+  &.failed {
+    span.failed {
+      display: inline-block;
+      color: $fail;
+    }
+  }
+  &.pending {
+    span.pending {
+      display: inline-block;
+      color: $pending;
+    }
+  }
+  &.running {
+    .spinner {
+      display: inline-block;
+      position: absolute;
+      background: darken($light2, 2.5%);
+      top: -0.925rem;
+      left: -0.667rem;
+      @include spinnerDonut($brand1, 1.333rem, 0.15rem);
+    }
+  }
+
+  .icon {
+    font-size: 1.5rem;
+    line-height: 0.5;
+    top: 1px;
+    left: -8px;
+    background: darken($light3, 3.5%);
+    position: absolute;
+    z-index: 900;
+    @include transition;
+
+    &.ion-checkmark-circled {
+      color: $success;
+    }
+
+    &.ion-close-circled {
+      color: $fail;
+    }
+  }
+
+  img {
+    position: relative;
+    left: -0.75rem;
+    top: -0.25rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    position: absolute;
+    z-index: 900;
+    background-color: $light1;
+    border-radius: 50%;
+  }
+
+  .spinner {
+    z-index: 900;
+    position: relative;
+    @include transition;
+  }
+
+  .unknown {
+    color: darken($light2, 12.5%);
+  }
+
+  &:after {
+    width: 0.125rem;
+    height: 2.75rem;
+    left: 0;
+    top: -0.25rem;
+    background: $light1;
+    position: absolute;
+    display: block;
+    content: " ";
+    z-index: 50;
+    opacity: 0.05;
+  }
+}

--- a/src/app/build-status-badge/build-status-badge.component.ts
+++ b/src/app/build-status-badge/build-status-badge.component.ts
@@ -8,11 +8,30 @@ import { Build } from '../models/Build';
   styleUrls: ['./build-status-badge.component.scss']
 })
 export class BuildStatusBadgeComponent implements OnInit {
-  @Input() build: Build;
+  @Input() status: string;
 
-  constructor() { }
-
-  ngOnInit() {
+  constructor() {
+    this.status = status;
   }
 
+  ngOnInit() { }
+
+  running(status) {
+    if (status === 'Running') {
+      return true;
+    }
+  }
+
+  calculateIconClass(status) {
+    switch (status) {
+      case 'Succeeded':
+        return 'icon ion-md-checkmark-circle';
+      case 'Failed':
+        return 'icon ion-md-close-circle';
+      case 'Pending':
+        return 'icon ion-md-clock';
+      default:
+        return 'icon ion-md-radio-button-off';
+    }
+  }
 }

--- a/src/app/mock/builds.ts
+++ b/src/app/mock/builds.ts
@@ -47,7 +47,7 @@ export const Builds: Build[] = [
     id: '01byy6vn3fanaypqpve7m1jwsf',
     project_id: 'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
-    provider: 'brigade-cli',
+    provider: 'github',
     revision: {
       commit: '',
       ref: ''
@@ -80,7 +80,7 @@ export const Builds: Build[] = [
       start_time: '2018-02-26T22:57:27Z',
       end_time: '2018-02-26T22:57:56Z',
       exit_code: 0,
-      status: 'Succeeded'
+      status: 'Running'
     }
   },
   {
@@ -127,7 +127,7 @@ export const Builds: Build[] = [
     id: '01bz3j29xmz4dhs99xahm1q9bh',
     project_id: 'brigade-830c16d4aaf6f5490937ad719afd8490a5bcbef064d397411043ac',
     type: 'exec',
-    provider: 'brigade-cli',
+    provider: 'github',
     revision: {
       commit: '',
       ref: ''
@@ -140,7 +140,7 @@ export const Builds: Build[] = [
       start_time: '2018-02-26T22:57:35Z',
       end_time: '2018-02-26T22:58:07Z',
       exit_code: 0,
-      status: 'Succeeded'
+      status: 'Pending'
     }
   },
   {

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -23,35 +23,7 @@
       <div *ngFor="let build of builds">
         <li class="medium-grid-block build-item ng-scope">
           <a routerLink="/builds/{{build.id}}" class="grid-block">
-            <!-- <app-build-status-badge [build]="build"></app-build-status-badge> -->
-            <span class="act-state collapse running">
-              <div class="spinner" title="Running"></div>
-            </span>
-
-            <span class="act-state collapse succeeded">
-              <div class="succeeded" title="Succeeded">
-                <i class="icon ion-md-checkmark-circle"></i>
-              </div>
-            </span>
-
-            <span class="act-state collapse failed">
-              <div class="failed" title="Failed">
-                <i class="icon ion-md-close-circle"></i>
-              </div>
-            </span>
-
-            <span class="act-state collapse unknown">
-              <span class="unknown">
-                <i class="icon ion-md-radio-button-off"></i>
-              </span>
-            </span>
-
-            <span class="act-state collapse pending">
-              <div class="pending">
-                <i class="icon ion-md-clock"></i>
-              </div>
-            </span>
-
+            <app-build-status-badge [status]="build.worker?.status"></app-build-status-badge>
             <span class="act-author ng-binding">
               <span class="act-avatar">
                 <i [ngClass]="CalculateProviderLogoClass(build.provider)"></i>

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -24,12 +24,12 @@
         <li class="medium-grid-block build-item ng-scope">
           <a routerLink="/builds/{{build.id}}" class="grid-block">
             <!-- <app-build-status-badge [build]="build"></app-build-status-badge> -->
-            <span class="act-state collapse active">
-              <div class="spinner" title="In progress"></div>
+            <span class="act-state collapse running">
+              <div class="spinner" title="Running"></div>
             </span>
 
-            <span class="act-state collapse success">
-              <div class="success" title="Succeeded">
+            <span class="act-state collapse succeeded">
+              <div class="succeeded" title="Succeeded">
                 <i class="icon ion-md-checkmark-circle"></i>
               </div>
             </span>
@@ -44,6 +44,12 @@
               <span class="unknown">
                 <i class="icon ion-md-radio-button-off"></i>
               </span>
+            </span>
+
+            <span class="act-state collapse pending">
+              <div class="pending">
+                <i class="icon ion-md-clock"></i>
+              </div>
             </span>
 
             <span class="act-author ng-binding">

--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -1,7 +1,6 @@
 @import 'global_variables';
 @import 'global_states';
 
-
 :host {
   min-width: 91.5%;
 }
@@ -276,102 +275,6 @@
         color: darken($dark3, 10%);
         display: inline-block;
         @include transition;
-      }
-
-      .act-state {
-        padding-top: 0.1rem;
-        padding-left: 0.1rem;
-        position: relative;
-        line-height: 1.725;
-        min-width: 3.5%;
-        z-index: 900;
-
-        div {
-          display: none;
-        }
-
-        &.succeeded {
-          div.succeeded {
-            display: inline-block;
-            color: $success;
-          }
-        }
-        &.failed {
-          div.failed {
-            display: inline-block;
-            color: $fail;
-          }
-        }
-        &.pending {
-          div.pending {
-            display: inline-block;
-            color: $pending;
-          }
-        }
-        &.running {
-          .spinner {
-            display: inline-block;
-            position: absolute;
-            background: darken($light2, 2.5%);
-            top: -0.925rem;
-            left: -0.667rem;
-            @include spinnerDonut($brand1, 1.333rem, 0.15rem);
-          }
-        }
-
-        .icon {
-          font-size: 1.5rem;
-          line-height: 0.5;
-          top: 1px;
-          left: -8px;
-          background: darken($light3, 3.5%);
-          position: absolute;
-          z-index: 900;
-          @include transition;
-
-          &.ion-checkmark-circled {
-            color: $success;
-          }
-
-          &.ion-close-circled {
-            color: $fail;
-          }
-        }
-
-        img {
-          position: relative;
-          left: -0.75rem;
-          top: -0.25rem;
-          width: 1.5rem;
-          height: 1.5rem;
-          position: absolute;
-          z-index: 900;
-          background-color: $light1;
-          border-radius: 50%;
-        }
-
-        .spinner {
-          z-index: 900;
-          position: relative;
-          @include transition;
-        }
-
-        .unknown {
-          color: darken($light2, 12.5%);
-        }
-
-        &:after {
-          width: 0.125rem;
-          height: 2.75rem;
-          left: 0;
-          top: -0.25rem;
-          background: $light1;
-          position: absolute;
-          display: block;
-          content: " ";
-          z-index: 50;
-          opacity: 0.05;
-        }
       }
 
       .act-author {

--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -67,12 +67,6 @@
   }
 }
 
-.project-header-wrap {
-  // position: relative;
-  // z-index: 200;
-  // padding: .75rem 2.75rem;
-}
-
 .project-header {
   min-height: 145px;
   background-color: $light3;
@@ -296,8 +290,8 @@
           display: none;
         }
 
-        &.success {
-          div.success {
+        &.succeeded {
+          div.succeeded {
             display: inline-block;
             color: $success;
           }
@@ -308,7 +302,13 @@
             color: $fail;
           }
         }
-        &.active {
+        &.pending {
+          div.pending {
+            display: inline-block;
+            color: $pending;
+          }
+        }
+        &.running {
           .spinner {
             display: inline-block;
             position: absolute;

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -10,6 +10,7 @@ import { BuildFactory } from '../tests/build-factory';
 import { ProjectComponent } from './project.component';
 import { Project } from '../models/Project';
 import { Build } from '../models/Build';
+import { BuildStatusBadgeComponent } from '../build-status-badge/build-status-badge.component';
 
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
@@ -19,7 +20,7 @@ describe('ProjectComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProjectComponent ],
+      declarations: [ ProjectComponent, BuildStatusBadgeComponent ],
       imports: [
         RouterTestingModule.withRoutes(
           [{ path: '', component: ProjectComponent }]


### PR DESCRIPTION
@technosophos @flynnduism Quick proposal to show how we might extract project build status to its own component.

- moved styles and template from project/ to build-status-component/
- demonstrates passing values from a parent component (`project.component`) to child component (`build-status-badge.component`).
- added 'Pending' status and renamed statuses to match [valid status values in Brigade](https://github.com/Azure/brigade/blob/435cb75130758a3dda1638879525868c0dec1776/pkg/brigade/job.go). Chose a clock icon for pending.
- used Angular's `ngIf` directive to toggle content based on a conditional. Did this because 4 statuses share the same HTML template while "Running" uses different HTML.
- for Succeeded, Failed, Pending, and Unknown statuses, I made the inner element a `<span>` to standardize them, as Unknown was a `<span>` while the others were a `<div`>

<img width="674" alt="kashti" src="https://user-images.githubusercontent.com/1231630/37865234-2c9dae48-2f3f-11e8-9980-011bf21681b9.png">

Assuming you like this design, still in need:
- CSS needs some cleanup
- unit tests