### PR TITLE
[#179] sort build list by timestamps

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { ProjectResolver } from './services/resolvers/project.resolver';
 import { BuildsResolver } from './services/resolvers/builds.resolver';
 import { ProjectsBuildResolver } from './services/resolvers/projects-build.resolver';
 import { BuildResolver } from './services/resolvers/build.resolver';
+import { SortBuildByStartDatePipe } from './pipes/builds/sort-build-by-start-date.pipe';
 
 @NgModule({
   declarations: [
@@ -32,7 +33,8 @@ import { BuildResolver } from './services/resolvers/build.resolver';
     FooterComponent,
     ProjectComponent,
     BuildComponent,
-    BuildStatusBadgeComponent
+    BuildStatusBadgeComponent,
+    SortBuildByStartDatePipe
   ],
   imports: [
     MomentModule,
@@ -48,7 +50,6 @@ import { BuildResolver } from './services/resolvers/build.resolver';
     ProjectsBuildResolver,
     BuildsResolver,
     BuildResolver
-
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
@@ -1,8 +1,65 @@
-import { SortBuildByStartDatePipe } from './sort-build-by-start-date.pipe';
+import {SortBuildByStartDatePipe, TimeDifference} from './sort-build-by-start-date.pipe';
+import {BuildFactory} from '../../tests/build-factory';
 
 describe('SortBuildByStartDatePipe', () => {
+  let pipe: SortBuildByStartDatePipe;
+  beforeEach(() => {
+    pipe = new SortBuildByStartDatePipe();
+  });
   it('should create', () => {
-    const pipe = new SortBuildByStartDatePipe();
     expect(pipe).toBeTruthy();
+  });
+  it('should not transform if no builds are given', () => {
+    const result = pipe.transform(undefined, false);
+    expect(result).toBe(undefined);
+  });
+  it('should not transform a list of equal elements', () => {
+    const mockBuilds = BuildFactory.buildList(5, {});
+    const result = pipe.transform(mockBuilds, true);
+    expect(result).toEqual(mockBuilds);
+  });
+  it('should compare two builds which have not been started as equal', () => {
+    const mockBuild = BuildFactory.build({ worker: undefined });
+    const result = SortBuildByStartDatePipe.compare(mockBuild, mockBuild);
+    expect(result).toEqual(TimeDifference.equal);
+  });
+  it('should show the first build to be earlier if it has not been started', () => {
+    const mockB1 = BuildFactory.build({ worker: undefined });
+    const mockB2 = BuildFactory.build({});
+    const result = SortBuildByStartDatePipe.compare(mockB1, mockB2);
+    expect(result).toEqual(TimeDifference.before);
+  });
+  it('should show the second build to be earlier if it has not been started', () => {
+    const mockB1 = BuildFactory.build({ worker: undefined });
+    const mockB2 = BuildFactory.build({});
+    const result = SortBuildByStartDatePipe.compare(mockB2, mockB1);
+    expect(result).toEqual(TimeDifference.after);
+  });
+  it('should compare two builds with equal start time as equal', () => {
+    const mockBuild = BuildFactory.build({});
+    const result = SortBuildByStartDatePipe.compare(mockBuild, mockBuild);
+    expect(result).toEqual(TimeDifference.equal);
+  });
+  it('should show the first build to be earlier if it\'s start time lies after', () => {
+    const mockB1 = BuildFactory.build({});
+    mockB1.worker.start_time = '2018-02-26T22:57:27Z';
+    const mockB2 = BuildFactory.build({ worker: undefined});
+    mockB2.worker = {
+      ... mockB1.worker,
+      start_time: '2018-02-28T22:57:27Z',
+    };
+    const result = SortBuildByStartDatePipe.compare(mockB1, mockB2);
+    expect(result).toEqual(TimeDifference.after);
+  });
+  it('should show the first build to be later if it\'s start time lies before', () => {
+    const mockB1 = BuildFactory.build({});
+    mockB1.worker.start_time = '2018-02-26T22:57:27Z';
+    const mockB2 = BuildFactory.build({ worker: undefined});
+    mockB2.worker = {
+      ... mockB1.worker,
+      start_time: '2018-02-21T22:57:27Z',
+    };
+    const result = SortBuildByStartDatePipe.compare(mockB1, mockB2);
+    expect(result).toEqual(TimeDifference.before);
   });
 });

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { SortBuildByStartDatePipe } from './sort-build-by-start-date.pipe';
+
+describe('SortBuildByStartDatePipe', () => {
+  it('should create', () => {
+    const pipe = new SortBuildByStartDatePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
@@ -1,6 +1,13 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import {Build} from '../../models/Build';
 
+// prevent magic numbers ...
+export enum TimeDifference {
+  equal = 0,
+  before = -1,
+  after = 1
+}
+
 @Pipe({
   name: 'sortBuildByStartDate'
 })
@@ -14,25 +21,20 @@ export class SortBuildByStartDatePipe implements PipeTransform {
    */
   static compare(b1: Build, b2: Build): number {
 
-    // prevent magic numbers ...
-    const equivalent = 0;
-    const before = -1;
-    const after = 1;
-
     // if both builds have no workers they are "equivalent" since they both have been recently
     // started
     if (!b1.worker && !b1.worker) {
-      return equivalent;
+      return TimeDifference.equal;
     }
 
     // if the the first build has no worker it is more recent than the second build
     if (!b1.worker) {
-      return before;
+      return TimeDifference.before;
     }
 
     // if the the second build has no worker it is more recent than the second build
     if (!b2.worker) {
-      return after;
+      return TimeDifference.after;
     }
 
     // we are sorting by start date
@@ -40,14 +42,14 @@ export class SortBuildByStartDatePipe implements PipeTransform {
     const startB2 = new Date(b2.worker.start_time).getTime();
 
     if (startB1 === startB2) {
-      return equivalent;
+      return TimeDifference.equal;
     }
 
     // smaller number in unix timestamp, the smaller the earlier ...
     if (startB1 < startB2) {
-      return after;
+      return TimeDifference.after;
     }
-    return before;
+    return TimeDifference.before;
   }
 
 

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
@@ -66,16 +66,11 @@ export class SortBuildByStartDatePipe implements PipeTransform {
     if (!builds) {
       return undefined;
     }
+    const order = desc ? -1 : 1;
 
-    let orderedList = builds.sort((b1, b2) => {
-      return SortBuildByStartDatePipe.compare(b1, b2);
+    return builds.sort((b1, b2) => {
+      return SortBuildByStartDatePipe.compare(b1, b2) * order;
     });
-
-    if (desc) {
-      orderedList = orderedList.reverse();
-    }
-
-    return orderedList;
   }
 
 }

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
@@ -21,19 +21,22 @@ export class SortBuildByStartDatePipe implements PipeTransform {
    */
   static compare(b1: Build, b2: Build): number {
 
+    const workerOneExists = !!b1.worker;
+    const workerTwoExists = !!b2.worker;
+
     // if both builds have no workers they are "equivalent" since they both have been recently
     // started
-    if (!b1.worker && !b1.worker) {
+    if ((!workerOneExists) && (!workerTwoExists)) {
       return TimeDifference.equal;
     }
 
     // if the the first build has no worker it is more recent than the second build
-    if (!b1.worker) {
+    if (!workerOneExists) {
       return TimeDifference.before;
     }
 
     // if the the second build has no worker it is more recent than the second build
-    if (!b2.worker) {
+    if (!workerTwoExists) {
       return TimeDifference.after;
     }
 

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
@@ -1,0 +1,76 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import {Build} from '../../models/Build';
+
+@Pipe({
+  name: 'sortBuildByStartDate'
+})
+export class SortBuildByStartDatePipe implements PipeTransform {
+
+  /**
+   * Compares two builds by their start time or if they haven't been started yet
+   * @param {Build} b1
+   * @param {Build} b2
+   * @returns {number} -1 if b1 is earlier, 0 if b1 and b2 are of the same time and 1 if b1 ist after b2
+   */
+  static compare(b1: Build, b2: Build): number {
+
+    // prevent magic numbers ...
+    const equivalent = 0;
+    const before = -1;
+    const after = 1;
+
+    // if both builds have no workers they are "equivalent" since they both have been recently
+    // started
+    if (!b1.worker && !b1.worker) {
+      return equivalent;
+    }
+
+    // if the the first build has no worker it is more recent than the second build
+    if (!b1.worker) {
+      return before;
+    }
+
+    // if the the second build has no worker it is more recent than the second build
+    if (!b2.worker) {
+      return after;
+    }
+
+    // we are sorting by start date
+    const startB1 = new Date(b1.worker.start_time).getTime();
+    const startB2 = new Date(b2.worker.start_time).getTime();
+
+    if (startB1 === startB2) {
+      return equivalent;
+    }
+
+    // smaller number in unix timestamp, the smaller the earlier ...
+    if (startB1 < startB2) {
+      return after;
+    }
+    return before;
+  }
+
+
+  /**
+   * Sorts a build array by start date (asc by default)
+   * @param {Build[]} builds to be sorted
+   * @param {boolean} desc if list should be ordered descending (older builds first)
+   * @returns {any}
+   */
+  transform(builds: Build[], desc: boolean): Build[] {
+    if (!builds) {
+      return undefined;
+    }
+
+    let orderedList = builds.sort((b1, b2) => {
+      return SortBuildByStartDatePipe.compare(b1, b2);
+    });
+
+    if (desc) {
+      orderedList = orderedList.reverse();
+    }
+
+    return orderedList;
+  }
+
+}

--- a/src/app/project/project.component.html
+++ b/src/app/project/project.component.html
@@ -20,7 +20,7 @@
     </div>
 
     <ul class="grid-content build-list columns">
-      <li class="medium-grid-block build-item" *ngFor="let build of builds">
+      <li class="medium-grid-block build-item" *ngFor="let build of (builds | sortBuildByStartDate)">
         <a routerLink="/builds/{{build.id}}" class="grid-block">
           <app-build-status-badge [status]="build.worker?.status"></app-build-status-badge>
           <span class="act-author" title="Build triggered by {{ build.provider }} / {{ build.type }}: commit {{ build.revision.commit }} ref {{ build.revision.ref }}">
@@ -48,7 +48,7 @@
 
             <!-- if completed -->
             <span class="act-times-wrap" *ngIf="
-              build.worker?.status == 'Failed' || 
+              build.worker?.status == 'Failed' ||
               build.worker?.status == 'Succeeded'
             ">
               <span class="act-time-duration">Build {{ build.worker?.status | lowercase }} after <span title="Build started {{ build.worker?.start_time | date:'long' }}">{{ build.worker?.start_time | amDifference: build.worker?.end_time :'seconds' : true | amDuration:'seconds' }}.</span></span>

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -11,6 +11,7 @@ import { ProjectComponent } from './project.component';
 import { Project } from '../models/Project';
 import { Build } from '../models/Build';
 import { BuildStatusBadgeComponent } from '../build-status-badge/build-status-badge.component';
+import {SortBuildByStartDatePipe} from '../pipes/builds/sort-build-by-start-date.pipe';
 
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
@@ -20,7 +21,7 @@ describe('ProjectComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProjectComponent, BuildStatusBadgeComponent ],
+      declarations: [ ProjectComponent, BuildStatusBadgeComponent, SortBuildByStartDatePipe ],
       imports: [
         RouterTestingModule.withRoutes(
           [{ path: '', component: ProjectComponent }]


### PR DESCRIPTION
This PR implements a sorting pipe so builds will be sorted by start date.
Closes #179 

This PR contains:
- a pipe implementation which sorts by start date and considers if builds have yet not been started (more recent builds)
- test cases to ensure functionality