### PR TITLE
feat(chart): proxy to the API

### DIFF
--- a/charts/kashti/templates/deployment.yaml
+++ b/charts/kashti/templates/deployment.yaml
@@ -32,12 +32,17 @@ spec:
           volumeMounts:
             - name: config-js
               mountPath: /usr/share/nginx/html/assets/js/settings
+            - name: config-nginx
+              mountPath: /etc/nginx/conf.d
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:
         - name: config-js
           configMap:
-            name: {{ template "fullname" . }}
+            name: {{ template "fullname" . }}-js
+        - name: config-nginx
+          configMap:
+            name: {{ template "fullname" . }}-nginx
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/kashti/templates/js-configmap.yaml
+++ b/charts/kashti/templates/js-configmap.yaml
@@ -1,3 +1,4 @@
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,5 +9,5 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   "settings.js": |-
-    var brigadeApiURL = '{{ default "http://localhost:7745" .Values.brigade.apiServer }}';
+    var brigadeApiURL = '//' + location.host; '{{ default "http://localhost:7745" .Values.brigade.apiServer }}';
     // End

--- a/charts/kashti/templates/js-configmap.yaml
+++ b/charts/kashti/templates/js-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "fullname" . }}-js
   labels:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name | quote }}

--- a/charts/kashti/templates/nginx-configmap.yaml
+++ b/charts/kashti/templates/nginx-configmap.yaml
@@ -12,16 +12,16 @@ data:
           listen       {{ .Values.service.internalPort }};
           server_name  localhost;
 
+        # Proxy to API server
+          location /v1/ {
+              proxy_pass {{ .Values.brigade.apiServer }}/v1/;
+          }
+
           location / {
               root   /usr/share/nginx/html;
               index  index.html index.htm;
           }
-
-          // Proxy to API server
-          location /v1 {
-              proxy_pass http://{{ .Values.brigade.apiServer }}/v1
-          }
-
+          
           error_page   500 502 503 504  /50x.html;
           location = /50x.html {
               root   /usr/share/nginx/html;

--- a/charts/kashti/templates/nginx-configmap.yaml
+++ b/charts/kashti/templates/nginx-configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-nginx
+  labels:
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service }}
+data:
+  "default.conf": |-
+      server {
+          listen       {{ .Values.service.internalPort }};
+          server_name  localhost;
+
+          location / {
+              root   /usr/share/nginx/html;
+              index  index.html index.htm;
+          }
+
+          // Proxy to API server
+          location /v1 {
+              proxy_pass http://{{ .Values.brigade.apiServer }}/v1
+          }
+
+          error_page   500 502 503 504  /50x.html;
+          location = /50x.html {
+              root   /usr/share/nginx/html;
+          }
+      }


### PR DESCRIPTION
This feat adds two things:

1. It exposes the nginx config file via a config map. This is useful for tweaking the way Kashti gets served (and could be used for adding auth)
2. It proxies the API calls (anything to `/v1/` into the Brigade API server, thus eliminating the need to expose the API server publicly

## To test:

Install:
```
$ helm install -n kashti charts/kashti --set brigade.apiServer="http://brigade-brigade-api.default.svc.cluster.local:7745"
```

(where the apiServer URL is the in-cluster domain name or IP address to your brigade API server)

Run `brig proxy` and open the URL in your browser. It should load the full dashboard.

In your browswer's developer tools, load the network view. Then reload the page. You should see the API calls go over `localhost:8081/v1` instead of directly against the API server.