### PR TITLE
Fix most linter errors

### DIFF
--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -18,21 +18,19 @@ import 'rxjs/add/operator/distinctUntilChanged';
 
 export class BreadcrumbComponent implements OnInit {
   location: Location;
-  
   breadcrumbs$ = this.router.events
       .filter(event => event instanceof NavigationEnd)
       .distinctUntilChanged()
       .map(event => this.buildBreadCrumb(this.activatedRoute.root));
-  
   // Build your breadcrumb starting with the root route of your current activated route
   constructor(
     private activatedRoute: ActivatedRoute,
     private router: Router,
-    location: Location) { this.location = location }
+    location: Location) { this.location = location; }
 
   backClicked() {
     this.location.back();
-  };
+  }
 
   ngOnInit() {}
 

--- a/src/app/build/build.component.ts
+++ b/src/app/build/build.component.ts
@@ -25,11 +25,11 @@ export class BuildComponent implements OnInit {
   jobs: Job[];
   location: Location;
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location }
+  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
 
   backClicked() {
     this.location.back();
-  };
+  }
 
   ngOnInit() {
     this.build = this.route.snapshot.data['build'];

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -18,11 +18,11 @@ export class DashboardComponent implements OnInit {
 
   projectsBuilds: ProjectsBuild[];
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location }
+  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
 
   backClicked() {
     this.location.back();
-  };
+  }
 
   ngOnInit() {
     this.projectsBuilds = this.route.snapshot.data['projectsBuilds'];

--- a/src/app/job/job.component.ts
+++ b/src/app/job/job.component.ts
@@ -18,11 +18,11 @@ export class JobComponent implements OnInit {
   log: Log;
   location: Location;
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location }
+  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
 
   backClicked() {
     this.location.back();
-  };
+  }
 
   ngOnInit() {
     this.job = this.route.snapshot.data['job'];

--- a/src/app/models/Breadcrumb.ts
+++ b/src/app/models/Breadcrumb.ts
@@ -1,4 +1,4 @@
 export interface BreadCrumb {
   label: string;
   url: string;
-};
+}

--- a/src/app/models/Log.ts
+++ b/src/app/models/Log.ts
@@ -1,3 +1,2 @@
 export interface Log {
-  
 }

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -20,11 +20,11 @@ export class ProjectComponent implements OnInit {
   builds: Build[];
   location: Location;
 
-  constructor(private route: ActivatedRoute, location: Location) { this.location = location }
+  constructor(private route: ActivatedRoute, location: Location) { this.location = location; }
 
   backClicked() {
     this.location.back();
-  };
+  }
 
   ngOnInit() {
     this.project = this.route.snapshot.data['project'];


### PR DESCRIPTION
This PR fixes most linter errors related to missing / unnecessary semicolons and trailing whitespaces.

The only remaining linter error is:

```
github.com/Azure/kashti/src/app/models/Log.ts[1, 18]: An empty interface is equivalent to `{}`.
```

This is related to the `Log` model being an empty interface.
@flynnduism - maybe we should have something like `message` for the unstructured data in a log object?