### PR TITLE
[201] fix breadcrumb component router error

### DIFF
--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -25,7 +25,7 @@ export class BreadcrumbComponent implements OnInit {
   // Build your breadcrumb starting with the root route of your current activated route
   constructor(
     private activatedRoute: ActivatedRoute,
-    private router: Router,
+    public router: Router,
     location: Location) { this.location = location; }
 
   backClicked() {


### PR DESCRIPTION
Sets the component's constructor to use public instead of private router

Closes #201.