### PR TITLE
Remove hardcoded URL for Brigade API

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,1 +1,1 @@
-export const BRIGADE_API_HOST = 'https://cors-anywhere.herokuapp.com/https://example-api.technosophos.me';
+export const BRIGADE_API_HOST = window.location.origin;


### PR DESCRIPTION
This PR removes the hardcoded URL to the demo API and fetches the current location of the page (since we proxy all requests for `/v1` to the Brigade API).