### PR TITLE
Add new demo target environment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -50,6 +50,27 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
+            },
+            "demo": {
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/app/app.config.ts",
+                  "with": "src/app/app.config.demo.ts"
+                },
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ]
             }
           }
         },
@@ -61,6 +82,9 @@
           "configurations": {
             "production": {
               "browserTarget": "kashti:build:production"
+            },
+            "demo": {
+              "browserTarget": "kashti:build:demo"
             }
           }
         },

--- a/src/app/app.config.demo.ts
+++ b/src/app/app.config.demo.ts
@@ -1,0 +1,1 @@
+export const BRIGADE_API_HOST = 'https://cors-anywhere.herokuapp.com/https://example-api.technosophos.me';	


### PR DESCRIPTION
This PR adds a new demo target environment so the demo instance (https://azure.github.io/kashti/) continues to work when built using: `ng build --configuration demo`.

To test this PR: `ng serve --configuration demo`.

This PR:

- adds a new `app.config.demo.ts` file which contains the URL for the demo instance of the Brigade API
- adds a new target environment in `angular.json`, which is the same as `production`, but replaces `app.config.ts` with `app.config.demo.ts` when used - the same technique used for the different environment files.

This PR does _not_ add an `environment.demo.ts`, as this would have resulted in circular dependencies in all service files: `environment.<env>.ts` (which has dependencies on all service types so we know what to inject based on the environment: mock or API service) -> `api.service.ts` (which would have taken a field off `environment` for the URL) -> `environment.ts` (for the URL field)

closes #205 