### PR TITLE
Fix imports order, remove unused imports, format documents

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true,
+    },
+    "editor.formatOnSave": true
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,51 +1,52 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-
 import { environment } from '../environments/environment';
-
-import { DashboardComponent } from './dashboard/dashboard.component';
-import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
-import { ProjectComponent } from './project/project.component';
 import { BuildComponent } from './build/build.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
 import { JobComponent } from './job/job.component';
-import { LogComponent } from './log/log.component';
-import { StyleGuideComponent } from './style-guide/style-guide.component';
-import { ProjectResolver } from './services/resolvers/project.resolver';
-import { BuildsResolver } from './services/resolvers/builds.resolver';
-import { ProjectsBuildResolver } from './services/resolvers/projects-build.resolver';
+import { ProjectComponent } from './project/project.component';
 import { BuildResolver } from './services/resolvers/build.resolver';
 import { BuildLogResolver } from './services/resolvers/buildlog.resolver';
-import { JobsResolver } from './services/resolvers/jobs.resolver';
+import { BuildsResolver } from './services/resolvers/builds.resolver';
 import { JobResolver } from './services/resolvers/job.resolver';
+import { JobsResolver } from './services/resolvers/jobs.resolver';
 import { LogResolver } from './services/resolvers/log.resolver';
+import { ProjectResolver } from './services/resolvers/project.resolver';
+import { ProjectsBuildResolver } from './services/resolvers/projects-build.resolver';
+import { StyleGuideComponent } from './style-guide/style-guide.component';
 
 const routes: Routes = [
-  { path: '',
+  {
+    path: '',
     redirectTo: '/dashboard',
     pathMatch: 'full'
   },
-  { path: 'dashboard',
+  {
+    path: 'dashboard',
     data: {
       breadcrumb: 'Home'
     },
     component: DashboardComponent,
     resolve: { projectsBuilds: ProjectsBuildResolver },
   },
-  { path: 'projects/:id',
+  {
+    path: 'projects/:id',
     data: {
       breadcrumb: 'Project'
     },
     component: ProjectComponent,
     resolve: { project: ProjectResolver, builds: BuildsResolver },
   },
-  { path: 'builds/:id',
+  {
+    path: 'builds/:id',
     data: {
       breadcrumb: 'Build'
     },
     component: BuildComponent,
     resolve: { build: BuildResolver, buildlog: BuildLogResolver, jobs: JobsResolver },
   },
-  { path: 'jobs/:id',
+  {
+    path: 'jobs/:id',
     data: {
       breadcrumb: 'Job'
     },

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,9 +1,9 @@
-import { TestBed, async } from '@angular/core/testing';
-import { AppComponent } from './app.component';
+import { async, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { SidebarComponent } from './sidebar/sidebar.component';
+import { AppComponent } from './app.component';
 import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
 import { FooterComponent } from './footer/footer.component';
+import { SidebarComponent } from './sidebar/sidebar.component';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,36 +1,33 @@
-import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
-import { MomentModule } from 'angular2-moment';
-
 import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { MomentModule } from 'angular2-moment';
 import { environment } from '../environments/environment';
-
-import { AppComponent } from './app.component';
-
-import { DashboardComponent } from './dashboard/dashboard.component';
 import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
 import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
-import { StyleGuideComponent } from './style-guide/style-guide.component';
-import { SidebarComponent } from './sidebar/sidebar.component';
-import { FooterComponent } from './footer/footer.component';
-import { ProjectComponent } from './project/project.component';
+import { BuildStatusBadgeComponent } from './build-status-badge/build-status-badge.component';
 import { BuildComponent } from './build/build.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { FooterComponent } from './footer/footer.component';
 import { JobComponent } from './job/job.component';
 import { LogComponent } from './log/log.component';
-import { BuildStatusBadgeComponent } from './build-status-badge/build-status-badge.component';
-import { ProjectService } from './services/project/project.service';
+import { SortBuildByStartDatePipe } from './pipes/builds/sort-build-by-start-date.pipe';
+import { ProjectComponent } from './project/project.component';
 import { BuildService } from './services/build/build.service';
 import { JobService } from './services/job/job.service';
 import { LogService } from './services/log/log.service';
-import { ProjectResolver } from './services/resolvers/project.resolver';
-import { ProjectsBuildResolver } from './services/resolvers/projects-build.resolver';
-import { BuildsResolver } from './services/resolvers/builds.resolver';
+import { ProjectService } from './services/project/project.service';
 import { BuildResolver } from './services/resolvers/build.resolver';
 import { BuildLogResolver } from './services/resolvers/buildlog.resolver';
-import { JobsResolver } from './services/resolvers/jobs.resolver';
+import { BuildsResolver } from './services/resolvers/builds.resolver';
 import { JobResolver } from './services/resolvers/job.resolver';
+import { JobsResolver } from './services/resolvers/jobs.resolver';
 import { LogResolver } from './services/resolvers/log.resolver';
-import { SortBuildByStartDatePipe } from './pipes/builds/sort-build-by-start-date.pipe';
+import { ProjectResolver } from './services/resolvers/project.resolver';
+import { ProjectsBuildResolver } from './services/resolvers/projects-build.resolver';
+import { SidebarComponent } from './sidebar/sidebar.component';
+import { StyleGuideComponent } from './style-guide/style-guide.component';
 
 @NgModule({
   declarations: [
@@ -69,4 +66,4 @@ import { SortBuildByStartDatePipe } from './pipes/builds/sort-build-by-start-dat
   ],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule { }

--- a/src/app/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/breadcrumb/breadcrumb.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { BreadcrumbComponent } from './breadcrumb.component';
 
 describe('BreadcrumbComponent', () => {
@@ -8,9 +7,9 @@ describe('BreadcrumbComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BreadcrumbComponent ]
+      declarations: [BreadcrumbComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -1,13 +1,11 @@
+import { Location } from '@angular/common';
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
-import { BreadCrumb } from '../models/breadcrumb';
-import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
-import 'rxjs/add/operator/distinctUntilChanged';
-
+import { BreadCrumb } from '../models/breadcrumb';
 
 @Component({
   selector: 'app-breadcrumb',
@@ -19,9 +17,9 @@ import 'rxjs/add/operator/distinctUntilChanged';
 export class BreadcrumbComponent implements OnInit {
   location: Location;
   breadcrumbs$ = this.router.events
-      .filter(event => event instanceof NavigationEnd)
-      .distinctUntilChanged()
-      .map(event => this.buildBreadCrumb(this.activatedRoute.root));
+    .filter(event => event instanceof NavigationEnd)
+    .distinctUntilChanged()
+    .map(event => this.buildBreadCrumb(this.activatedRoute.root));
   // Build your breadcrumb starting with the root route of your current activated route
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -32,26 +30,26 @@ export class BreadcrumbComponent implements OnInit {
     this.location.back();
   }
 
-  ngOnInit() {}
+  ngOnInit() { }
 
   buildBreadCrumb(route: ActivatedRoute, url: string = '',
-                  breadcrumbs: Array<BreadCrumb> = []): Array<BreadCrumb> {
-      // If no routeConfig is avalailable we are on the root path
-      const label = route.routeConfig ? route.routeConfig.data[ 'breadcrumb' ] : 'Home';
-      const path = route.routeConfig ? route.routeConfig.path : '';
-      // In the routeConfig the complete path is not available,
-      // so we rebuild it each time
-      const nextUrl = `${url}${path}/`;
-      const breadcrumb = {
-          label: label,
-          url: nextUrl
-      };
-      const newBreadcrumbs = [ ...breadcrumbs, breadcrumb ];
-      if (route.firstChild) {
-          // If we are not on our current path yet,
-          // there will be more children to look after, to build our breadcumb
-          return this.buildBreadCrumb(route.firstChild, nextUrl, newBreadcrumbs);
-      }
-      return newBreadcrumbs;
+    breadcrumbs: Array<BreadCrumb> = []): Array<BreadCrumb> {
+    // If no routeConfig is avalailable we are on the root path
+    const label = route.routeConfig ? route.routeConfig.data['breadcrumb'] : 'Home';
+    const path = route.routeConfig ? route.routeConfig.path : '';
+    // In the routeConfig the complete path is not available,
+    // so we rebuild it each time
+    const nextUrl = `${url}${path}/`;
+    const breadcrumb = {
+      label: label,
+      url: nextUrl
+    };
+    const newBreadcrumbs = [...breadcrumbs, breadcrumb];
+    if (route.firstChild) {
+      // If we are not on our current path yet,
+      // there will be more children to look after, to build our breadcumb
+      return this.buildBreadCrumb(route.firstChild, nextUrl, newBreadcrumbs);
+    }
+    return newBreadcrumbs;
   }
 }

--- a/src/app/build-status-badge/build-status-badge.component.spec.ts
+++ b/src/app/build-status-badge/build-status-badge.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { BuildStatusBadgeComponent } from './build-status-badge.component';
 
 describe('BuildStatusBadgeComponent', () => {
@@ -8,9 +7,9 @@ describe('BuildStatusBadgeComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BuildStatusBadgeComponent ]
+      declarations: [BuildStatusBadgeComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/build-status-badge/build-status-badge.component.ts
+++ b/src/app/build-status-badge/build-status-badge.component.ts
@@ -1,6 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
-
-import { Build } from '../models/build';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
   selector: 'app-build-status-badge',
@@ -18,7 +16,7 @@ export class BuildStatusBadgeComponent implements OnInit {
 
   running(status) {
     if (status === 'Pending' ||
-        status === 'Running') {
+      status === 'Running') {
       return true;
     }
   }

--- a/src/app/build/build.component.spec.ts
+++ b/src/app/build/build.component.spec.ts
@@ -1,7 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { BuildComponent } from './build.component';
 
 describe('BuildComponent', () => {
@@ -21,7 +20,7 @@ describe('BuildComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ BuildComponent ],
+      declarations: [BuildComponent],
       imports: [
         RouterTestingModule.withRoutes(
           [{ path: '', component: BuildComponent }]
@@ -29,10 +28,10 @@ describe('BuildComponent', () => {
       ],
       providers: [{
         provide: ActivatedRoute,
-        useValue: {snapshot: {data: {'build': build}}}
+        useValue: { snapshot: { data: { 'build': build } } }
       }]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/build/build.component.ts
+++ b/src/app/build/build.component.ts
@@ -1,16 +1,11 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
-
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Build } from '../models/build';
 import { BuildLog } from '../models/build-log';
-import { Revision } from '../models/revision';
 import { BuildWorker } from '../models/build-worker';
 import { Job } from '../models/job';
-
-import { MomentModule } from 'angular2-moment';
-import { LongDateFormatKey } from 'moment';
+import { Revision } from '../models/revision';
 
 @Component({
   selector: 'app-build',

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,10 +1,9 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
-import { DashboardComponent } from './dashboard.component';
 import { MomentModule } from 'angular2-moment/moment.module';
 import { ProjectService } from '../services/project/project.service';
+import { DashboardComponent } from './dashboard.component';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -12,7 +11,7 @@ describe('DashboardComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ],
+      declarations: [DashboardComponent],
       imports: [
         RouterTestingModule.withRoutes(
           [{ path: '', component: DashboardComponent }]
@@ -20,9 +19,9 @@ describe('DashboardComponent', () => {
         MomentModule,
         HttpClientTestingModule
       ],
-      providers: [ ProjectService ]
+      providers: [ProjectService]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,10 +1,6 @@
-import { Component, OnInit, Inject } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-
-import { MomentModule } from 'angular2-moment';
-
-import { ProjectService } from '../services/project/project.service';
 import { ProjectsBuild } from '../models/projects-build';
 
 @Component({

--- a/src/app/footer/footer.component.spec.ts
+++ b/src/app/footer/footer.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {
@@ -8,9 +7,9 @@ describe('FooterComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ FooterComponent ]
+      declarations: [FooterComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/footer/footer.component.ts
+++ b/src/app/footer/footer.component.ts
@@ -6,10 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./footer.component.scss']
 })
 export class FooterComponent implements OnInit {
-
+  
   constructor() { }
 
   ngOnInit() {
   }
-
 }

--- a/src/app/job/job.component.spec.ts
+++ b/src/app/job/job.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { JobComponent } from './job.component';
 
 describe('JobComponent', () => {
@@ -8,9 +7,9 @@ describe('JobComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ JobComponent ]
+      declarations: [JobComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/job/job.component.ts
+++ b/src/app/job/job.component.ts
@@ -1,16 +1,14 @@
+import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
+import { ActivatedRoute } from '@angular/router';
 import 'rxjs/add/operator/switchMap';
-
 import { Job } from '../models/job';
 import { Log } from '../models/log';
 
 @Component({
   selector: 'app-job',
   templateUrl: './job.component.html',
-  providers: [Location, {provide: LocationStrategy, useClass: PathLocationStrategy}],
+  providers: [Location, { provide: LocationStrategy, useClass: PathLocationStrategy }],
   styleUrls: ['../build/build.component.scss']
 })
 export class JobComponent implements OnInit {

--- a/src/app/log/log.component.spec.ts
+++ b/src/app/log/log.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { LogComponent } from './log.component';
 
 describe('LogComponent', () => {
@@ -8,9 +7,9 @@ describe('LogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ LogComponent ]
+      declarations: [LogComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/log/log.component.ts
+++ b/src/app/log/log.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
+import { ActivatedRoute } from '@angular/router';
 import 'rxjs/add/operator/switchMap';
-
 import { Log } from '../models/log';
 
 @Component({
@@ -13,7 +11,7 @@ import { Log } from '../models/log';
 export class LogComponent implements OnInit {
   log: Log;
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute) { }
 
   ngOnInit() {
     this.log = this.route.snapshot.data['log'];

--- a/src/app/mock/build-logs.ts
+++ b/src/app/mock/build-logs.ts
@@ -1,3 +1,1 @@
-import { BuildLog } from '../models/build-log';
-
 export const BuildLogs = 'failed to get container status \{\"docker\" \"b1cc04067500011ed83475ccce6d3c2cc7cf5abdd20b9264f4a27c629d08a72a\"\}\: rpc error\: code \= Unknown desc \= Error\: No such container\: b1cc04067500011ed83475ccce6d3c2cc7cf5abdd20b9264f4a27c629d08a72a'

--- a/src/app/models/build-log.ts
+++ b/src/app/models/build-log.ts
@@ -1,3 +1,3 @@
 export interface BuildLog {
-  
+
 }

--- a/src/app/models/build-worker.ts
+++ b/src/app/models/build-worker.ts
@@ -1,4 +1,3 @@
-
 export interface BuildWorker {
   id: string;
   build_id: string;

--- a/src/app/models/build.ts
+++ b/src/app/models/build.ts
@@ -1,5 +1,5 @@
-import { Revision } from './revision';
 import { BuildWorker } from './build-worker';
+import { Revision } from './revision';
 
 export interface Build {
   id: string;

--- a/src/app/models/log.ts
+++ b/src/app/models/log.ts
@@ -1,2 +1,3 @@
 export interface Log {
+    
 }

--- a/src/app/models/project.ts
+++ b/src/app/models/project.ts
@@ -1,5 +1,5 @@
-import { Repo } from './repo';
 import { Kubernetes } from './kubernetes';
+import { Repo } from './repo';
 import { Worker } from './worker';
 
 export interface Project {

--- a/src/app/models/projects-build.ts
+++ b/src/app/models/projects-build.ts
@@ -1,7 +1,5 @@
-import { Project } from './project';
-import { Repo } from './repo';
-import { Kubernetes } from './kubernetes';
 import { LastBuild } from './last-build';
+import { Project } from './project';
 
 export interface ProjectsBuild {
   project: Project;

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.spec.ts
@@ -1,5 +1,5 @@
-import {SortBuildByStartDatePipe, TimeDifference} from './sort-build-by-start-date.pipe';
-import {BuildFactory} from '../../tests/build-factory';
+import { BuildFactory } from '../../tests/build-factory';
+import { SortBuildByStartDatePipe, TimeDifference } from './sort-build-by-start-date.pipe';
 
 describe('SortBuildByStartDatePipe', () => {
   let pipe: SortBuildByStartDatePipe;
@@ -43,9 +43,9 @@ describe('SortBuildByStartDatePipe', () => {
   it('should show the first build to be earlier if it\'s start time lies after', () => {
     const mockB1 = BuildFactory.build({});
     mockB1.worker.start_time = '2018-02-26T22:57:27Z';
-    const mockB2 = BuildFactory.build({ worker: undefined});
+    const mockB2 = BuildFactory.build({ worker: undefined });
     mockB2.worker = {
-      ... mockB1.worker,
+      ...mockB1.worker,
       start_time: '2018-02-28T22:57:27Z',
     };
     const result = SortBuildByStartDatePipe.compare(mockB1, mockB2);
@@ -54,9 +54,9 @@ describe('SortBuildByStartDatePipe', () => {
   it('should show the first build to be later if it\'s start time lies before', () => {
     const mockB1 = BuildFactory.build({});
     mockB1.worker.start_time = '2018-02-26T22:57:27Z';
-    const mockB2 = BuildFactory.build({ worker: undefined});
+    const mockB2 = BuildFactory.build({ worker: undefined });
     mockB2.worker = {
-      ... mockB1.worker,
+      ...mockB1.worker,
       start_time: '2018-02-21T22:57:27Z',
     };
     const result = SortBuildByStartDatePipe.compare(mockB1, mockB2);

--- a/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
+++ b/src/app/pipes/builds/sort-build-by-start-date.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import {Build} from '../../models/build';
+import { Build } from '../../models/build';
 
 // prevent magic numbers ...
 export enum TimeDifference {

--- a/src/app/project/project.component.spec.ts
+++ b/src/app/project/project.component.spec.ts
@@ -1,17 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MomentModule } from 'angular2-moment/moment.module';
-
-import { ProjectFactory } from '../tests/project-factory';
-import { BuildFactory } from '../tests/build-factory';
-
-import { ProjectComponent } from './project.component';
-import { Project } from '../models/project';
-import { Build } from '../models/build';
 import { BuildStatusBadgeComponent } from '../build-status-badge/build-status-badge.component';
-import {SortBuildByStartDatePipe} from '../pipes/builds/sort-build-by-start-date.pipe';
+import { Build } from '../models/build';
+import { Project } from '../models/project';
+import { SortBuildByStartDatePipe } from '../pipes/builds/sort-build-by-start-date.pipe';
+import { BuildFactory } from '../tests/build-factory';
+import { ProjectFactory } from '../tests/project-factory';
+import { ProjectComponent } from './project.component';
 
 describe('ProjectComponent', () => {
   let component: ProjectComponent;
@@ -21,7 +18,7 @@ describe('ProjectComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProjectComponent, BuildStatusBadgeComponent, SortBuildByStartDatePipe ],
+      declarations: [ProjectComponent, BuildStatusBadgeComponent, SortBuildByStartDatePipe],
       imports: [
         RouterTestingModule.withRoutes(
           [{ path: '', component: ProjectComponent }]
@@ -30,10 +27,10 @@ describe('ProjectComponent', () => {
       ],
       providers: [{
         provide: ActivatedRoute,
-        useValue: {snapshot: {data: {'project': mockProject, builds: mockBuilds}}}
+        useValue: { snapshot: { data: { 'project': mockProject, builds: mockBuilds } } }
       }]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -47,8 +44,8 @@ describe('ProjectComponent', () => {
   });
   describe('when there is project and build data available', () => {
     beforeEach(() => {
-      mockProject = ProjectFactory.build({name: 'coffeesnob'});
-      mockBuilds = BuildFactory.buildList(2, {id: 'coffeebuild'});
+      mockProject = ProjectFactory.build({ name: 'coffeesnob' });
+      mockBuilds = BuildFactory.buildList(2, { id: 'coffeebuild' });
     });
 
     it('should create the component', () => {

--- a/src/app/project/project.component.ts
+++ b/src/app/project/project.component.ts
@@ -1,13 +1,9 @@
-import { Component, OnInit, HostBinding } from '@angular/core';
-import { Location, LocationStrategy, PathLocationStrategy} from '@angular/common';
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/switchMap';
-
-import { Project } from '../models/project';
 import { Build } from '../models/build';
-
-import { MomentModule } from 'angular2-moment';
+import { Project } from '../models/project';
 
 @Component({
   selector: 'app-project',

--- a/src/app/services/build/api-build.service.spec.ts
+++ b/src/app/services/build/api-build.service.spec.ts
@@ -1,14 +1,6 @@
-import { TestBed, inject, async } from '@angular/core/testing';
-import {
-  HttpClientModule,
-  HttpRequest,
-  HttpParams
-} from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from '@angular/common/http/testing';
-
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { async, inject, TestBed } from '@angular/core/testing';
 import { ApiBuildService } from './api-build.service';
 
 describe('ApiBuildService', () => {

--- a/src/app/services/build/api-build.service.ts
+++ b/src/app/services/build/api-build.service.ts
@@ -1,13 +1,10 @@
-import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
-import { catchError, map, tap } from 'rxjs/operators';
 import { BRIGADE_API_HOST } from '../../app.config';
-import { BuildService } from './build.service';
 import { Build } from '../../models/build';
 import { BuildLog } from '../../models/build-log';
-
+import { BuildService } from './build.service';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
@@ -15,7 +12,7 @@ const httpOptions = {
 
 @Injectable()
 export class ApiBuildService implements BuildService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   getBuilds(projectId): Observable<Build[]> {
     const buildsUrl = `${BRIGADE_API_HOST}/v1/project/${projectId}/builds`;
@@ -33,7 +30,7 @@ export class ApiBuildService implements BuildService {
 
   getBuildLog(buildId): Observable<BuildLog> {
     const buildlogUrl = `${BRIGADE_API_HOST}/v1/build/${buildId}/logs?stream=true`;
-    const options = {responseType: 'text' as 'json'};
+    const options = { responseType: 'text' as 'json' };
 
     return this.http
       .get<BuildLog>(buildlogUrl, options);

--- a/src/app/services/build/build.service.ts
+++ b/src/app/services/build/build.service.ts
@@ -1,7 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { Build } from '../../models/build';
 import { BuildLog } from '../../models/build-log';
-import { Job } from '../../models/job';
 
 export abstract class BuildService {
     abstract getBuilds(projectId: string): Observable<Build[]>;

--- a/src/app/services/build/mock-build.service.ts
+++ b/src/app/services/build/mock-build.service.ts
@@ -1,11 +1,10 @@
+import 'rxjs/add/observable/of';
+import { Observable } from 'rxjs/Observable';
+import { BuildLogs } from '../../mock/build-logs';
+import { Builds } from '../../mock/builds';
 import { Build } from '../../models/build';
 import { BuildLog } from '../../models/build-log';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-
 import { BuildService } from './build.service';
-import { Builds } from '../../mock/builds';
-import { BuildLogs } from '../../mock/build-logs';
 
 export class MockBuildService implements BuildService {
   getBuilds(projectId: string): Observable<Build[]> {
@@ -17,8 +16,8 @@ export class MockBuildService implements BuildService {
 
   getBuild(buildId: string): Observable<Build> {
     const filteredList =
-    Builds.filter((build: Build) => build.id === buildId);
-  return Observable.of(filteredList[0]).delay(500);
+      Builds.filter((build: Build) => build.id === buildId);
+    return Observable.of(filteredList[0]).delay(500);
   }
 
   getBuildLog(buildId: string): Observable<BuildLog> {

--- a/src/app/services/job/api-job.service.spec.ts
+++ b/src/app/services/job/api-job.service.spec.ts
@@ -1,14 +1,6 @@
-import { TestBed, inject, async } from '@angular/core/testing';
-import {
-  HttpClientModule,
-  HttpRequest,
-  HttpParams
-} from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from '@angular/common/http/testing';
-
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { async, inject, TestBed } from '@angular/core/testing';
 import { ApiJobService } from './api-job.service';
 
 describe('ApiJobService', () => {

--- a/src/app/services/job/api-job.service.ts
+++ b/src/app/services/job/api-job.service.ts
@@ -1,12 +1,9 @@
-import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
-import { catchError, map, tap } from 'rxjs/operators';
 import { BRIGADE_API_HOST } from '../../app.config';
-import { JobService } from './job.service';
 import { Job } from '../../models/job';
-
+import { JobService } from './job.service';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
@@ -14,7 +11,7 @@ const httpOptions = {
 
 @Injectable()
 export class ApiJobService implements JobService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   getJobs(buildId): Observable<Job[]> {
     const jobsUrl = `${BRIGADE_API_HOST}/v1/build/${buildId}/jobs`;

--- a/src/app/services/job/job.service.ts
+++ b/src/app/services/job/job.service.ts
@@ -1,5 +1,4 @@
 import { Observable } from 'rxjs/Observable';
-import { Build } from '../../models/build';
 import { Job } from '../../models/job';
 
 export abstract class JobService {

--- a/src/app/services/job/mock-job.service.ts
+++ b/src/app/services/job/mock-job.service.ts
@@ -1,13 +1,8 @@
-import { Build } from '../../models/build';
-import { Job } from '../../models/job';
-import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-
-import { BuildService } from '../build/build.service';
-import { JobService } from './job.service';
-import { Builds } from '../../mock/builds';
+import { Observable } from 'rxjs/Observable';
 import { Jobs } from '../../mock/jobs';
-import { filter } from 'rxjs/operators';
+import { Job } from '../../models/job';
+import { JobService } from './job.service';
 
 export class MockJobService implements JobService {
   getJobs(buildId: string): Observable<Job[]> {
@@ -16,7 +11,7 @@ export class MockJobService implements JobService {
 
   getJob(jobId: string): Observable<Job> {
     const filteredList =
-    Jobs.filter((job: Job) => job.id === jobId);
-  return Observable.of(filteredList[0]).delay(500);
+      Jobs.filter((job: Job) => job.id === jobId);
+    return Observable.of(filteredList[0]).delay(500);
   }
 }

--- a/src/app/services/log/api-log.service.spec.ts
+++ b/src/app/services/log/api-log.service.spec.ts
@@ -1,14 +1,6 @@
-import { TestBed, inject, async } from '@angular/core/testing';
-import {
-  HttpClientModule,
-  HttpRequest,
-  HttpParams
-} from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from '@angular/common/http/testing';
-
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
 import { ApiLogService } from './api-log.service';
 
 describe('ApiLogService', () => {

--- a/src/app/services/log/api-log.service.ts
+++ b/src/app/services/log/api-log.service.ts
@@ -1,12 +1,9 @@
-import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
-import { catchError, map, tap } from 'rxjs/operators';
 import { BRIGADE_API_HOST } from '../../app.config';
-import { LogService } from './log.service';
 import { Log } from '../../models/log';
-
+import { LogService } from './log.service';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
@@ -15,11 +12,11 @@ const httpOptions = {
 
 @Injectable()
 export class ApiLogService implements LogService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   getLog(jobId): Observable<Log> {
     const logUrl = `${BRIGADE_API_HOST}/v1/job/${jobId}/logs?stream=true`;
-    const options = {responseType: 'text' as 'json'};
+    const options = { responseType: 'text' as 'json' };
 
     return this.http
       .get<Log>(logUrl, options);

--- a/src/app/services/log/log.service.ts
+++ b/src/app/services/log/log.service.ts
@@ -1,5 +1,4 @@
 import { Observable } from 'rxjs/Observable';
-import { Job } from '../../models/job';
 import { Log } from '../../models/log';
 
 export abstract class LogService {

--- a/src/app/services/log/mock-log.service.ts
+++ b/src/app/services/log/mock-log.service.ts
@@ -1,13 +1,8 @@
-import { Job } from '../../models/job';
-import { Log } from '../../models/log';
-import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-
-import { JobService } from '../job/job.service';
-import { LogService } from './log.service';
-import { Jobs } from '../../mock/jobs';
+import { Observable } from 'rxjs/Observable';
 import { LogData } from '../../mock/logs';
-import { filter } from 'rxjs/operators';
+import { Log } from '../../models/log';
+import { LogService } from './log.service';
 
 export class MockLogService implements LogService {
 

--- a/src/app/services/project/api-project.service.ts
+++ b/src/app/services/project/api-project.service.ts
@@ -1,25 +1,19 @@
-import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { of } from 'rxjs/observable/of';
-import { catchError, map, tap } from 'rxjs/operators';
-
-import { environment } from '../../../environments/environment.prod';
-import { ProjectsBuild } from '../../models/projects-build';
-import { Project } from '../../models/project';
-import { ProjectService } from './project.service';
 import { BRIGADE_API_HOST } from '../../app.config';
+import { Project } from '../../models/project';
+import { ProjectsBuild } from '../../models/projects-build';
+import { ProjectService } from './project.service';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
 };
 
-
-
 @Injectable()
 export class ApiProjectService implements ProjectService {
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient) { }
 
   getProjectBuilds(): Observable<ProjectsBuild[]> {
     const projectBuildsUrl = `${BRIGADE_API_HOST}/v1/projects-build`;

--- a/src/app/services/project/mock-project.service.ts
+++ b/src/app/services/project/mock-project.service.ts
@@ -1,25 +1,22 @@
 import { Injectable } from '@angular/core';
-import { ProjectService } from './project.service';
-import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/delay';
-
-import { ProjectsBuild } from '../../models/projects-build';
-import { Project } from '../../models/project';
-
-import { ProjectsBuilds } from '../../mock/projects-builds';
+import { Observable } from 'rxjs/Observable';
 import { Projects } from '../../mock/projects';
-import { filter } from 'rxjs/operators';
+import { ProjectsBuilds } from '../../mock/projects-builds';
+import { Project } from '../../models/project';
+import { ProjectsBuild } from '../../models/projects-build';
+import { ProjectService } from './project.service';
 
 @Injectable()
 export class MockProjectService implements ProjectService {
-    getProjectBuilds(): Observable<ProjectsBuild[]> {
-        return Observable.of(ProjectsBuilds).delay(500);
-    }
+  getProjectBuilds(): Observable<ProjectsBuild[]> {
+    return Observable.of(ProjectsBuilds).delay(500);
+  }
 
-    getProject(projectId: string): Observable<Project> {
-      const filteredList =
-        Projects.filter((project: Project) => project.id === projectId);
-      return Observable.of(filteredList[0]).delay(500);
-    }
+  getProject(projectId: string): Observable<Project> {
+    const filteredList =
+      Projects.filter((project: Project) => project.id === projectId);
+    return Observable.of(filteredList[0]).delay(500);
+  }
 }

--- a/src/app/services/project/project.service.spec.ts
+++ b/src/app/services/project/project.service.spec.ts
@@ -1,14 +1,6 @@
-import { TestBed, inject, async } from '@angular/core/testing';
-import {
-  HttpClientModule,
-  HttpRequest,
-  HttpParams
-} from '@angular/common/http';
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from '@angular/common/http/testing';
-
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { async, inject, TestBed } from '@angular/core/testing';
 import { ApiProjectService } from './api-project.service';
 
 describe('ApiProjectService', () => {

--- a/src/app/services/project/project.service.ts
+++ b/src/app/services/project/project.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs/Observable';
-import { ProjectsBuild } from '../../models/projects-build';
 import { Project } from '../../models/project';
+import { ProjectsBuild } from '../../models/projects-build';
 
 export abstract class ProjectService {
     abstract getProjectBuilds(): Observable<ProjectsBuild[]>;

--- a/src/app/services/resolvers/build.resolver.spec.ts
+++ b/src/app/services/resolvers/build.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { BuildResolver } from './build.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { BuildService } from '../build/build.service';
-
+import { BuildResolver } from './build.resolver';
 
 describe('BuildResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/build.resolver.ts
+++ b/src/app/services/resolvers/build.resolver.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { BuildService } from '../build/build.service';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Build } from '../../models/build';
-import { BuildLog } from '../../models/build-log';
+import { BuildService } from '../build/build.service';
 
 @Injectable()
 export class BuildResolver implements Resolve<Build> {
 
-  constructor(private buildService: BuildService) {}
+  constructor(private buildService: BuildService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.buildService.getBuild(route.paramMap.get('id'));

--- a/src/app/services/resolvers/buildlog.resolver.ts
+++ b/src/app/services/resolvers/buildlog.resolver.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { BuildService } from '../build/build.service';
-import { Build } from '../../models/build';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { BuildLog } from '../../models/build-log';
+import { BuildService } from '../build/build.service';
 
 @Injectable()
 export class BuildLogResolver implements Resolve<BuildLog> {
 
-  constructor(private buildService: BuildService) {}
+  constructor(private buildService: BuildService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.buildService.getBuildLog(route.paramMap.get('id'));

--- a/src/app/services/resolvers/builds.resolver.spec.ts
+++ b/src/app/services/resolvers/builds.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { BuildsResolver } from './builds.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { BuildService } from '../build/build.service';
-
+import { BuildsResolver } from './builds.resolver';
 
 describe('BuildsResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/builds.resolver.ts
+++ b/src/app/services/resolvers/builds.resolver.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { BuildService } from '../build/build.service';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Build } from '../../models/build';
+import { BuildService } from '../build/build.service';
 
 @Injectable()
 export class BuildsResolver implements Resolve<Build[]> {
 
-  constructor(private buildService: BuildService) {}
+  constructor(private buildService: BuildService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.buildService.getBuilds(route.paramMap.get('id'));

--- a/src/app/services/resolvers/job.resolver.spec.ts
+++ b/src/app/services/resolvers/job.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { BuildResolver } from './build.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { BuildService } from '../build/build.service';
-
+import { BuildResolver } from './build.resolver';
 
 describe('BuildResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/job.resolver.ts
+++ b/src/app/services/resolvers/job.resolver.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { JobService } from '../job/job.service';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Job } from '../../models/job';
+import { JobService } from '../job/job.service';
 
 @Injectable()
 export class JobResolver implements Resolve<Job> {
 
-  constructor(private jobService: JobService) {}
+  constructor(private jobService: JobService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.jobService.getJob(route.paramMap.get('id'));

--- a/src/app/services/resolvers/jobs.resolver.spec.ts
+++ b/src/app/services/resolvers/jobs.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { BuildsResolver } from './builds.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { BuildService } from '../build/build.service';
-
+import { BuildsResolver } from './builds.resolver';
 
 describe('BuildsResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/jobs.resolver.ts
+++ b/src/app/services/resolvers/jobs.resolver.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { JobService } from '../job/job.service';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Job } from '../../models/job';
+import { JobService } from '../job/job.service';
 
 @Injectable()
 export class JobsResolver implements Resolve<Job[]> {
 
-  constructor(private jobService: JobService) {}
+  constructor(private jobService: JobService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.jobService.getJobs(route.paramMap.get('id'));

--- a/src/app/services/resolvers/log.resolver.spec.ts
+++ b/src/app/services/resolvers/log.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { JobResolver } from './job.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { JobService } from '../job/job.service';
-
+import { JobResolver } from './job.resolver';
 
 describe('JobResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/log.resolver.ts
+++ b/src/app/services/resolvers/log.resolver.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { LogService } from '../log/log.service';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { Log } from '../../models/log';
+import { LogService } from '../log/log.service';
 
 @Injectable()
 export class LogResolver implements Resolve<Log> {
 
-  constructor(private logService: LogService) {}
+  constructor(private logService: LogService) { }
 
   resolve(route: ActivatedRouteSnapshot) {
     return this.logService.getLog(route.paramMap.get('id'));

--- a/src/app/services/resolvers/project.resolver.spec.ts
+++ b/src/app/services/resolvers/project.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { ProjectResolver } from './project.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { ProjectService } from '../project/project.service';
-
+import { ProjectResolver } from './project.resolver';
 
 describe('ProjectResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/project.resolver.ts
+++ b/src/app/services/resolvers/project.resolver.ts
@@ -1,15 +1,14 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import 'rxjs/add/operator/catch';
-
-import { ProjectService } from '../project/project.service';
+import { Observable } from 'rxjs/Observable';
 import { Project } from '../../models/project';
+import { ProjectService } from '../project/project.service';
 
 @Injectable()
 export class ProjectResolver implements Resolve<Project> {
 
-  constructor(private projectService: ProjectService) {}
+  constructor(private projectService: ProjectService) { }
 
   resolve(route: ActivatedRouteSnapshot): Observable<Project> {
     return this.projectService.getProject(route.paramMap.get('id'))

--- a/src/app/services/resolvers/projects-build.resolver.spec.ts
+++ b/src/app/services/resolvers/projects-build.resolver.spec.ts
@@ -1,8 +1,6 @@
-import { TestBed, inject } from '@angular/core/testing';
-
-import { ProjectResolver } from './project.resolver';
+import { inject, TestBed } from '@angular/core/testing';
 import { ProjectService } from '../project/project.service';
-
+import { ProjectResolver } from './project.resolver';
 
 describe('ProjectResolver', () => {
   beforeEach(() => {

--- a/src/app/services/resolvers/projects-build.resolver.ts
+++ b/src/app/services/resolvers/projects-build.resolver.ts
@@ -1,13 +1,12 @@
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
-
-import { ProjectService } from '../project/project.service';
+import { Resolve } from '@angular/router';
 import { ProjectsBuild } from '../../models/projects-build';
+import { ProjectService } from '../project/project.service';
 
 @Injectable()
 export class ProjectsBuildResolver implements Resolve<ProjectsBuild[]> {
 
-  constructor(private projectService: ProjectService) {}
+  constructor(private projectService: ProjectService) { }
 
   resolve() {
     return this.projectService.getProjectBuilds();

--- a/src/app/sidebar/sidebar.component.spec.ts
+++ b/src/app/sidebar/sidebar.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SidebarComponent } from './sidebar.component';
 
 describe('SidebarComponent', () => {
@@ -8,9 +7,9 @@ describe('SidebarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SidebarComponent ]
+      declarations: [SidebarComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -11,5 +11,4 @@ export class SidebarComponent implements OnInit {
 
   ngOnInit() {
   }
-
 }

--- a/src/app/style-guide/style-guide.component.spec.ts
+++ b/src/app/style-guide/style-guide.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { StyleGuideComponent } from './style-guide.component';
 
 describe('StyleGuideComponent', () => {
@@ -8,9 +7,9 @@ describe('StyleGuideComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ StyleGuideComponent ]
+      declarations: [StyleGuideComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/app/tests/build-factory.ts
+++ b/src/app/tests/build-factory.ts
@@ -1,5 +1,4 @@
 import * as Factory from 'factory.ts';
-
 import { Build } from '../models/build';
 
 export const BuildFactory = Factory.makeFactory<Build>({

--- a/src/app/tests/project-factory.ts
+++ b/src/app/tests/project-factory.ts
@@ -1,5 +1,4 @@
 import * as Factory from 'factory.ts';
-
 import { Project } from '../models/project';
 
 export const ProjectFactory = Factory.makeFactory<Project>({

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,7 +1,7 @@
 import { ApiBuildService } from '../app/services/build/api-build.service';
-import { ApiProjectService } from '../app/services/project/api-project.service';
 import { ApiJobService } from '../app/services/job/api-job.service';
 import { ApiLogService } from '../app/services/log/api-log.service';
+import { ApiProjectService } from '../app/services/project/api-project.service';
 
 export const environment = {
   production: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,7 @@
-import { MockProjectService } from '../app/services/project/mock-project.service';
 import { MockBuildService } from '../app/services/build/mock-build.service';
 import { MockJobService } from '../app/services/job/mock-job.service';
 import { MockLogService } from '../app/services/log/mock-log.service';
+import { MockProjectService } from '../app/services/project/mock-project.service';
 
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+
 
 if (environment.production) {
   enableProdMode();

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,16 +1,13 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import 'zone.js/dist/async-test';
+import 'zone.js/dist/fake-async-test';
+import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';
 import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
-import { getTestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare const __karma__: any;


### PR DESCRIPTION
This PR re-organizes the imports on all components and re-formats the files.

If using VS Code, the following settings will ensure the files remain consistently formatted and the imports in order (and this PR adds a workspace settings file in `.vscode/settings.json`):

```
	"editor.codeActionsOnSave": {
		"source.organizeImports": true,
	},
	"editor.formatOnSave": true
```

The one issue I haven't dealt with yet - the blank lines in files - `gofmt` and `goimports` surely spoiled my preferences... 😄 