### PR TITLE
Update unit and end-to-end tests to use headless Chrome

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,6 @@
+FROM node:8
+
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable

--- a/brigade.js
+++ b/brigade.js
@@ -5,19 +5,13 @@ events.on("push", (e, project) => {
   // this is DinD.
   var driver = project.secrets.DOCKER_DRIVER || "overlay"
 
-  const unitTests = new Job("dev", "node:8")
+  const unitTests = new Job("dev", "radumatei/node-chrome-headless:node8")
   unitTests.tasks = [
     "cd /src",
     "yarn install",
+    "yarn global add @angular/cli",
     "ng lint",
-    "ng test --single-run",
-    "ng e2e"
-  ]
-
-  const e2e = new Job("dev", "node:8")
-  e2e.tasks = [
-    "cd /src",
-    "yarn install",
+    "ng test --browsers=ChromeHeadless",
     "ng e2e"
   ]
 
@@ -47,7 +41,7 @@ events.on("push", (e, project) => {
   }
 
   // Run unit and e2e tests in parallel. Once both finish, run docker build.
-  Group.runAll([unitTests, e2e]).then( () => {
+  Group.runAll([unitTests]).then(() => {
     return docker.run()
   });
 });
@@ -61,11 +55,11 @@ events.on("exec", (e, p) => {
   var j4 = alpineJob("four")
   var j5 = alpineJob("five")
 
-  j1.run().then( () => { return j2.run() }).then( () => {
+  j1.run().then(() => { return j2.run() }).then(() => {
     var g = new Group()
     g.add(j3)
     g.add(j4)
-    g.runAll().then( () => {j5.run()})
+    g.runAll().then(() => { j5.run() })
   })
 });
 

--- a/brigade.js
+++ b/brigade.js
@@ -5,7 +5,7 @@ events.on("push", (e, project) => {
   // this is DinD.
   var driver = project.secrets.DOCKER_DRIVER || "overlay"
 
-  const unitTests = new Job("dev", "radumatei/node-chrome-headless:node8")
+  const unitTests = new Job("dev", "deis/node-chrome:node8")
   unitTests.tasks = [
     "cd /src",
     "yarn install",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 // Karma configuration file, see link for more information
-// https://karma-runner.github.io/0.13/config/configuration-file.html
+// https://karma-runner.github.io/1.0/config/configuration-file.html
 
 module.exports = function (config) {
   config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 // Karma configuration file, see link for more information
-// https://karma-runner.github.io/1.0/config/configuration-file.html
+// https://karma-runner.github.io/0.13/config/configuration-file.html
 
 module.exports = function (config) {
   config.set({
@@ -12,20 +12,31 @@ module.exports = function (config) {
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
-    client:{
+    client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, 'coverage'), reports: [ 'html', 'lcovonly' ],
+      dir: require('path').join(__dirname, 'coverage'), reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },
-    
+
     reporters: ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false
+    browsers: ['ChromeHeadless', 'Chrome'],
+    customLaunchers: {
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          '--no-sandbox',
+          '--remote-debugging-port=9222'
+        ]
+      }
+    },
+    singleRun: true
   });
 };

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -11,7 +11,7 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome',
     'chromeOptions': {
-      'args': ['--no-sandbox', '--headless', '--window-size=1024,768']
+      'args': ['--no-sandbox', '--headless']
     }
   },
   directConnect: true,

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -9,7 +9,10 @@ exports.config = {
     './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    'browserName': 'chrome'
+    'browserName': 'chrome',
+    'chromeOptions': {
+      'args': ['--no-sandbox', '--headless', '--window-size=1024,768']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
@@ -17,7 +20,7 @@ exports.config = {
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function() {}
+    print: function () { }
   },
   onPrepare() {
     require('ts-node').register({


### PR DESCRIPTION
This PR adds Karma and Protractor config for headless Chrome + updates the Brigade pipeline with a job in a container with Chrome.