### PR TITLE
feat(charts/kashti): add checksum annotations to deployment

### DIFF
--- a/charts/kashti/templates/deployment.yaml
+++ b/charts/kashti/templates/deployment.yaml
@@ -11,6 +11,9 @@ spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        checksum/config-js: {{ include (print $.Template.BasePath "/js-configmap.yaml") . | sha256sum }}
+        checksum/config-nginx: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
       labels:
         app: {{ template "name" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
Thus, a pod for this deployment will be recreated if either of the configmaps change (ex:`brigade.apiServer` value changes)