### PR TITLE
Restructure CI

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,3 @@
 {
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": true,
-    },
     "editor.formatOnSave": true
 }

--- a/brigade.js
+++ b/brigade.js
@@ -69,20 +69,21 @@ function test() {
 
 function githubRelease(e, project) {
   const gh = JSON.parse(e.payload);
-  const start = ghNotify("pending", `build started as ${e.buildID}`, e, project)
   if (gh.ref.startsWith("refs/tags/") || gh.ref == "refs/heads/master") {
+    const start = ghNotify("pending", `release started as ${e.buildID}`, e, project)
+
     let parts = gh.ref.split("/", 3);
     let tag = parts[2];
     var releaser = new ACRBuildJob(`${projectName}-release`, projectName, tag, "/src", project.secrets.acrName, project.secrets.acrToken, project.secrets.acrTenant);
     var latestReleaser = new ACRBuildJob(`${projectName}-release-latest`, projectName, "latest", "/src", project.secrets.acrName, project.secrets.acrToken, project.secrets.acrTenant);
     Group.runAll([start, releaser, latestReleaser])
       .catch(err => {
-        return ghNotify("failure", `failed build ${e.buildID}`, e, project).run()
+        return ghNotify("failure", `failed release ${e.buildID}`, e, project).run()
       });
+    return ghNotify("success", `release ${e.buildID} finished successfully`, e, project).run()
   } else {
     console.log('not a tag or a push to master; skipping')
   }
-  return ghNotify("success", `build ${e.buildID} passed`, e, project).run()
 }
 
 function githubTest(e, project) {

--- a/brigade.js
+++ b/brigade.js
@@ -29,17 +29,12 @@ class E2eJob extends Job {
 }
 
 class ACRBuildJob extends Job {
-  constructor(name, img, tag, dir, registry, token, tenant) {
+  constructor(name, img, tag, dir, registry, username, token, tenant) {
     super(name, "microsoft/azure-cli:latest");
     let imgName = img + ":" + tag;
-    this.env = {
-      AZURE_CONTAINER_REGISTRY: registry,
-      ACR_TOKEN: token,
-      ACR_TENANT: tenant,
-    }
     this.tasks = [
-      // Create a service principal and assign it proper perms on the container registry.
-      `az login --service-principal -u $AZURE_CONTAINER_REGISTRY -p $ACR_TOKEN --tenant $ACR_TENANT`,
+      // service principal should have proper perms on the container registry.
+      `az login --service-principal -u ${username} -p ${token} --tenant ${tenant}`,
       `cd ${dir}`,
       `echo '========> building ${img}...'`,
       `az acr build -r ${registry} -t ${imgName} .`,
@@ -74,8 +69,8 @@ function githubRelease(e, project) {
 
     let parts = gh.ref.split("/", 3);
     let tag = parts[2];
-    var releaser = new ACRBuildJob(`${projectName}-release`, projectName, tag, "/src", project.secrets.acrName, project.secrets.acrToken, project.secrets.acrTenant);
-    var latestReleaser = new ACRBuildJob(`${projectName}-release-latest`, projectName, "latest", "/src", project.secrets.acrName, project.secrets.acrToken, project.secrets.acrTenant);
+    var releaser = new ACRBuildJob(`${projectName}-release`, projectName, tag, "/src", project.secrets.acrName, project.secrets.acrUsername, project.secrets.acrToken, project.secrets.acrTenant);
+    var latestReleaser = new ACRBuildJob(`${projectName}-release-latest`, projectName, "latest", "/src", project.secrets.acrName, project.secrets.acrUsername, project.secrets.acrToken, project.secrets.acrTenant);
     Group.runAll([start, releaser, latestReleaser])
       .catch(err => {
         return ghNotify("failure", `failed release ${e.buildID}`, e, project).run()

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['ChromeHeadless', 'Chrome'],
+    browserNoActivityTimeout: 30000,
     customLaunchers: {
       ChromeHeadless: {
         base: 'Chrome',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,6 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['ChromeHeadless', 'Chrome'],
-    browserNoActivityTimeout: 30000,
     customLaunchers: {
       ChromeHeadless: {
         base: 'Chrome',

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,1 +1,1 @@
-@import 'global_variables';
+@import '../global_variables';

--- a/src/app/breadcrumb/breadcrumb.component.scss
+++ b/src/app/breadcrumb/breadcrumb.component.scss
@@ -1,4 +1,4 @@
-@import 'global_variables';
+@import '../../global_variables';
 
 #breadcrumbbar {
   position: fixed;

--- a/src/app/build-status-badge/build-status-badge.component.scss
+++ b/src/app/build-status-badge/build-status-badge.component.scss
@@ -1,5 +1,5 @@
-@import 'global_variables';
-@import 'global_states';
+@import '../../global_variables';
+@import '../../global_states';
 
 span {
   font-family: $mono;

--- a/src/app/build/build.component.scss
+++ b/src/app/build/build.component.scss
@@ -1,5 +1,5 @@
-@import 'global_variables';
-@import 'global_states';
+@import '../../global_variables';
+@import '../../global_states';
 
 :host {
   min-width: 91.5%;

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -1,5 +1,5 @@
-@import 'global_variables';
-@import 'global_states';
+@import '../../global_variables';
+@import '../../global_states';
 
 
 :host {

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@import 'global_variables';
+@import '../../global_variables';
 
 footer {
   border-top: 2px solid rgba(55,55,55,0.025);

--- a/src/app/project/project.component.scss
+++ b/src/app/project/project.component.scss
@@ -1,5 +1,5 @@
-@import 'global_variables';
-@import 'global_states';
+@import '../../global_variables';
+@import '../../global_states';
 
 :host {
   min-width: 91.5%;

--- a/src/app/sidebar/sidebar.component.scss
+++ b/src/app/sidebar/sidebar.component.scss
@@ -1,4 +1,4 @@
-@import 'global_variables';
+@import '../../global_variables';
 
 
 #sidebar {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,20 +1,23 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import { getTestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
-import 'zone.js/dist/jasmine-patch';
+// Note: ordering matters for the imports below and should not be auto-sorted
+// See https://github.com/angular/zone.js/issues/404
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';
 import 'zone.js/dist/sync-test';
+import 'zone.js/dist/jasmine-patch';
+import 'zone.js/dist/async-test';
+import 'zone.js/dist/fake-async-test';
+
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare const __karma__: any;
 declare const require: any;
 
 // Prevent Karma from running prematurely.
-__karma__.loaded = function () {};
+__karma__.loaded = function () { };
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(


### PR DESCRIPTION
This picks up where https://github.com/Azure/kashti/pull/214 left of (though, removing the GitHub Checks logic for this round.)

Changes besides those in `brigade.js` have been prompted by actually running test/e2e/etc. tasks on the codebase.