### PR TITLE
Add RouterTestingModule ref in Log and Breadcrumb component tests

### DIFF
--- a/src/app/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/breadcrumb/breadcrumb.component.spec.ts
@@ -1,8 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { BreadcrumbComponent } from './breadcrumb.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MomentModule } from 'angular2-moment';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { BreadcrumbComponent } from './breadcrumb.component';
 
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
@@ -17,8 +17,7 @@ describe('BreadcrumbComponent', () => {
         ),
         MomentModule,
         HttpClientTestingModule
-      ],
-      // roviders: [ProjectService]
+      ]
     })
       .compileComponents();
   }));

--- a/src/app/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/breadcrumb/breadcrumb.component.spec.ts
@@ -1,5 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { BreadcrumbComponent } from './breadcrumb.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MomentModule } from 'angular2-moment';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
@@ -7,7 +10,15 @@ describe('BreadcrumbComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [BreadcrumbComponent]
+      declarations: [BreadcrumbComponent],
+      imports: [
+        RouterTestingModule.withRoutes(
+          [{ path: '', component: BreadcrumbComponent }]
+        ),
+        MomentModule,
+        HttpClientTestingModule
+      ],
+      // roviders: [ProjectService]
     })
       .compileComponents();
   }));

--- a/src/app/log/log.component.spec.ts
+++ b/src/app/log/log.component.spec.ts
@@ -1,5 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { LogComponent } from './log.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MomentModule } from 'angular2-moment/moment.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('LogComponent', () => {
   let component: LogComponent;
@@ -7,7 +10,15 @@ describe('LogComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [LogComponent]
+      declarations: [LogComponent],
+      imports: [
+        RouterTestingModule.withRoutes(
+          [{ path: '', component: LogComponent }]
+        ),
+        MomentModule,
+        HttpClientTestingModule
+      ],
+      // roviders: [ProjectService]
     })
       .compileComponents();
   }));

--- a/src/app/log/log.component.spec.ts
+++ b/src/app/log/log.component.spec.ts
@@ -1,8 +1,8 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { LogComponent } from './log.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MomentModule } from 'angular2-moment/moment.module';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { LogComponent } from './log.component';
 
 describe('LogComponent', () => {
   let component: LogComponent;
@@ -17,8 +17,7 @@ describe('LogComponent', () => {
         ),
         MomentModule,
         HttpClientTestingModule
-      ],
-      // roviders: [ProjectService]
+      ]
     })
       .compileComponents();
   }));


### PR DESCRIPTION
This PR fixes the `Error: StaticInjectorError[ActivatedRoute]: ` errors in the tests we see in #227 by adding references to `RouterTestingModule` in `LogComponent` and `BreadcrumbComponent`.

Now running `ng test` no longer errors out, but somehow (at least my instance of headless Chrome on Mac) gets disconnected - not sure it's because all tests have been completed or something else is happening - will continue to investigate, but in theory this should unblock #227 

```
radu:kashti $ ng test
 10% building modules 1/1 modules 0 active(node:44549) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
03 10 2018 20:57:51.185:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
03 10 2018 20:57:51.186:INFO [launcher]: Launching browsers ChromeHeadless, Chrome with unlimited concurrency
03 10 2018 20:57:51.192:INFO [launcher]: Starting browser Chrome
03 10 2018 20:57:51.197:INFO [launcher]: Starting browser Chrome
03 10 2018 20:57:57.716:INFO [HeadlessChrome 0.0.0 (Mac OS X 10.13.1)]: Connected on socket u1owKrNaecsjKO3UAAAA with id 98556207
03 10 2018 20:57:57.751:INFO [Chrome 69.0.3497 (Mac OS X 10.13.1)]: Connected on socket whkCS4uh-IPj8jl5AAAB with id 64843532
Chrome 69.0.3497 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) SUCCESS (0 secs / 0.363 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.13.1): Executed 4 of 42 SUCCESS (0 secs / 0.427 secs)
03 10 2018 20:58:11.141:WARN [Chrome 69.0.3497 (Mac OS X 10.13.1)]: Disconnected (1 times), because no message in 10000 ms.
Chrome 69.0.3497 (Mac OS X 10.13.1) ERROR
  Disconnected, because no message in 10000 ms.
Chrome 69.0.3497 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.376 secs / 0.363 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) SUCCESS (0 secs / 0.427 secs)
Chrome 69.0.3497 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.376 secs / 0.363 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) SUCCESS (0 secs / 0.427 secs)
03 10 2018 20:58:11.227:WARN [HeadlessChrome 0.0.0 (Mac OS X 10.13.1)]: Disconnected (1 times), because no message in 10000 ms.
HeadlessChrome 0.0.0 (Mac OS X 10.13.1) ERROR
  Disconnected, because no message in 10000 ms.
Chrome 69.0.3497 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.376 secs / 0.363 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.437 secs / 0.427 secs)
Chrome 69.0.3497 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.376 secs / 0.363 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.13.1): Executed 4 of 42 (skipped 1) DISCONNECTED (10.437 secs / 0.427 secs)
```

cc @vdice 