### PR TITLE
Fix helm chart path for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ image:
 ```console
 $ eval $(minikube docker-env)
 $ yarn docker-build
-$ helm install -n brigade-ui chart/kashti --set brigade.apiServer=http://localhost:7745
+$ helm install -n brigade-ui charts/kashti --set brigade.apiServer=http://localhost:7745
 ```
 
 This will push a copy of the Docker image into your Minikube docker registry and


### PR DESCRIPTION
The README describes how to install the brigade ui on a minikube cluster.

Expectation: As I go through the commands in the README, I should be able to paste them into my terminal and they should work.

What happened: When I pasted the `helm install` command, I got the following letting me know it couldn't find the directory.
```
$ helm install -n brigade-ui chart/kashti --set brigade.apiServer=http://localhost:7745
Error: failed to download "chart/kashti" (hint: running `helm repo update` may help)
```

Fix: Change the path from `chart` to `charts` to match the actual directory.